### PR TITLE
Sync skill docs from monorepo (PR #12541)

### DIFF
--- a/plugins/relevance-ai/skills/managing-relevance-agents/creating.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/creating.md
@@ -17,7 +17,29 @@ interface AgentConfig {
   params_schema?: object; // Input variables
   autonomy_limit?: number; // Max tool calls (default: 20)
   autonomy_limit_behaviour?: string; // What happens at limit
+  model_options?: {
+    // Model configuration
+    max_output_tokens?: number; // Max response length (e.g. 16000)
+  };
 }
+```
+
+### `model_options` — NOT a top-level field
+
+`max_output_tokens` and other model settings live inside `model_options`, **not** as top-level agent fields. Setting them at the top level causes a 422 error.
+
+```typescript
+// WRONG — 422 error: unknown top-level field
+relevance_save_agent_draft({
+  agentId: '...',
+  agentConfig: { ...agent, max_output_tokens: 16000 },
+});
+
+// CORRECT — nested inside model_options
+relevance_save_agent_draft({
+  agentId: '...',
+  agentConfig: { ...agent, model_options: { max_output_tokens: 16000 } },
+});
 ```
 
 ## Agent Features (Enabled via Settings)

--- a/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
@@ -4,6 +4,48 @@ Common issues and fixes for Relevance AI agents.
 
 ## Critical Issues
 
+### `relevance_save_agent_draft` Warns About Empty Actions
+
+**Symptom:** Saving an agent returns a warning about `actions` being empty.
+
+**Cause:** The `relevance_save_agent_draft` API uses PUT semantics — omitted fields get wiped. The warning helps catch accidental omissions (e.g. forgetting to include existing tools).
+
+**When it's safe to ignore:** If the agent intentionally has no tools, the warning is a false positive. The save still proceeds — it's a warning, not a block.
+
+**When to act:** If the agent should have tools, fetch the full config first:
+
+```typescript
+// Fetch full config, merge your changes, save complete object
+const { agent } = await relevance_get_agent({
+  agent_id: '...',
+  summary: false,
+});
+await relevance_save_agent_draft({
+  agent_id: '...',
+  config: { ...agent, system_prompt: 'updated prompt' },
+});
+```
+
+**Tip:** For targeted edits (system prompt, model, etc.), use `relevance_patch_agent` instead — it handles fetch/merge/save internally and avoids this issue entirely.
+
+### Agent Max Output Tokens — 422 Error
+
+**Symptom:** Setting `max_output_tokens` or `max_tokens` on an agent returns a 422 error.
+
+**Cause:** `max_output_tokens` is NOT a top-level agent field — it lives inside `model_options`.
+
+**Fix:**
+
+```typescript
+// WRONG — 422 error
+{ ...agent, max_output_tokens: 16000 }
+
+// CORRECT — nested inside model_options
+{ ...agent, model_options: { max_output_tokens: 16000 } }
+```
+
+See [creating.md](creating.md) for the full `model_options` reference.
+
 ### Agent Config Wiped After Update
 
 **Symptom:** Agent lost system prompt, tools, or other config after saving.

--- a/plugins/relevance-ai/skills/managing-relevance-workforces/concepts.md
+++ b/plugins/relevance-ai/skills/managing-relevance-workforces/concepts.md
@@ -132,6 +132,31 @@ Controls whether agents share conversation context.
 
 **Important:** For sequential pipelines where agents need to see previous outputs, use `always-same`.
 
+### `always-create-new` Data Flow — Critical Design Pattern
+
+When using `always-create-new` threading (common in tool-call edges where orchestrators invoke sub-agents), each sub-agent runs in an **isolated conversation**. This has critical implications:
+
+1. **Parent agents can only read sub-agent response text** — they cannot access sub-agent tool call results, artifacts, or internal state
+2. **Sub-agents cannot be re-queried** — each invocation creates a new task/thread, so asking "what was the URL you created?" in a follow-up call starts a fresh conversation with no memory
+3. **Sub-agents must report all important data in their response text** — URLs, file paths, key results, etc.
+
+```
+// WRONG — Orchestrator calls Writer, then tries to ask for the DOCX URL
+Orchestrator → Writer: "Write an article about X"       // Writer creates DOCX
+Orchestrator → Writer: "What was the DOCX URL?"         // NEW thread — Writer has no memory!
+
+// CORRECT — Writer includes URL in its response text
+Writer system prompt includes:
+  "Your response MUST end with: **DOCX URL:** [exact URL from save tool]"
+Orchestrator reads the URL from Writer's response text
+```
+
+**When designing `always-create-new` workflows:**
+
+- Instruct sub-agents to include all output data (URLs, IDs, results) in their response text
+- Have orchestrator agents extract data from sub-agent responses, not re-query
+- If an orchestrator needs to pass data between sub-agents, extract from one response and include in the next invocation message
+
 ## Action Config (tool-call edges only)
 
 When using `tool-call` edges, you can configure how the source agent invokes the target:

--- a/plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md
+++ b/plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md
@@ -164,6 +164,21 @@ const execution = await relevance_get_workforce_task_messages({
 }
 ```
 
+### Orchestrator can't find sub-agent output (URLs, file paths, etc.)
+
+**Cause:** `always-create-new` threading means the orchestrator can only read sub-agent response text — it cannot access tool call results or re-query the sub-agent (each call creates a fresh thread).
+
+**Fix:** Instruct sub-agents to include all important outputs in their response text:
+
+```
+// Add to sub-agent system prompt:
+"Your response MUST include the DOCX URL on its own line:
+**DOCX URL:** [exact URL from the save tool]
+The parent agent can ONLY read your response text."
+```
+
+Then have the orchestrator extract data from the sub-agent's response text. See [concepts.md](concepts.md) > Threading > `always-create-new` Data Flow for details.
+
 ### Agent with tools appears to have no tools
 
 **Cause:** Wrong `region` in agent's actions


### PR DESCRIPTION
## Summary
- Syncs skill doc updates from `relevance-api-node` [PR #12541](https://github.com/RelevanceAI/relevance-api-node/pull/12541) that were added to `packages/relevance-skills/` but not carried over here
- **agents/creating.md**: `model_options` field documentation and "NOT a top-level field" gotcha
- **agents/troubleshooting.md**: 3 new sections — empty actions warning, max_output_tokens 422 error, `relevance_patch_agent` recommendation
- **workforces/concepts.md**: `always-create-new` data flow design pattern (parent can't access sub-agent tool results)
- **workforces/debugging.md**: "Orchestrator can't find sub-agent output" troubleshooting entry

## Test plan
- [ ] Verify skill docs render correctly in Claude Code plugin
- [ ] Confirm content matches monorepo source of truth (`packages/relevance-skills/skills/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)