### PR TITLE
Update agent skills: pending_approval, timed_out, OAuth verification

### DIFF
--- a/plugins/relevance-ai/skills/managing-relevance-agents/creating.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/creating.md
@@ -158,7 +158,14 @@ relevance_save_agent_draft({
 relevance_publish_agent({ agentId: agent.agent_id });
 ```
 
-### Step 5: Test
+### Step 5: Verify OAuth Integrations
+
+If any attached tools require OAuth (check `params_schema` for `metadata.content_type === "oauth_account"`), verify the connection:
+
+1. Call `relevance_list_oauth_accounts` to check connected accounts
+2. If a required provider is missing, call `relevance_get_project_info` to get the integrations page URL and direct the user to connect it
+
+### Step 6: Test
 
 ```typescript
 relevance_trigger_agent({
@@ -200,9 +207,11 @@ This reveals:
         |
 4. Publish (relevance_publish_agent)
         |
-5. Test (relevance_trigger_agent)
+5. Verify OAuth (relevance_list_oauth_accounts + relevance_get_project_info)
         |
-6. Add triggers if needed (relevance_create_trigger)
+6. Test (relevance_trigger_agent)
+        |
+7. Add triggers if needed (relevance_create_trigger)
 ```
 
 ## Model Options

--- a/plugins/relevance-ai/skills/managing-relevance-agents/running.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/running.md
@@ -130,12 +130,14 @@ const task = await relevance_get_task_view({
 
 ### Common Issues
 
-| Symptom                 | Likely Cause              | Fix                             |
-| ----------------------- | ------------------------- | ------------------------------- |
-| Agent doesn't use tools | System prompt unclear     | Make tool instructions explicit |
-| Tool execution fails    | Missing project/region    | Add to action config            |
-| Wrong tool called       | Tool descriptions unclear | Update action descriptions      |
-| Slow response           | Too many tools            | Remove unused tools             |
+| Symptom                          | Likely Cause                          | Fix                                                                                         |
+| -------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Agent doesn't use tools          | System prompt unclear                 | Make tool instructions explicit                                                              |
+| Tool execution fails             | Missing project/region                | Add to action config                                                                         |
+| Wrong tool called                | Tool descriptions unclear             | Update action descriptions                                                                   |
+| Slow response                    | Too many tools                        | Remove unused tools                                                                          |
+| `pending_approval` status        | `action_behaviour: "always-ask"`      | Approve in UI, or change to `"never-ask"` for automated use                                  |
+| `timed_out` status               | Agent takes >120s                     | Use `relevance_get_task_view` to poll — do NOT re-trigger                                    |
 
 ## URL Patterns
 
@@ -199,6 +201,18 @@ if (page1.next_cursor) {
 - `cursor.before` - Get messages before this ISO timestamp (for going back in time)
 - `cursor.after` - Get messages after this ISO timestamp (for new messages)
 
+## Dry Run / Safe Testing Pattern
+
+For agents with potentially destructive tools (e.g. sending emails, deleting data), set `action_behaviour: "always-ask"` on those tools using `relevance_patch_agent` during testing.
+
+When triggered, the agent will pause at `pending_approval` status before executing the tool. You can:
+
+1. Review the tool call parameters in the Relevance AI app (use `relevance_get_project_info` for the URL)
+2. Approve or reject the call
+3. Use `relevance_get_task_view` to see the result after approval
+
+Once verified, switch back to `"never-ask"` for production use.
+
 ## Best Practices
 
 1. **Test incrementally** - Start with simple messages before complex workflows
@@ -206,3 +220,4 @@ if (page1.next_cursor) {
 3. **Verify tool outputs** - Ensure tools return expected data
 4. **Test with diverse inputs** - Don't rely on a single test; use varied inputs to reveal edge cases
 5. **Monitor for timeouts** - Long tool operations may timeout
+6. **Never re-trigger on timeout or pending_approval** - Use `relevance_get_task_view` to poll instead

--- a/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
@@ -242,6 +242,25 @@ actions: [{
 | Wrong model         | Try higher-capability model     |
 | Missing context     | Include relevant info in prompt |
 
+### Agent Stuck on Pending Approval
+
+**Symptom:** `relevance_trigger_agent` returns `status: "pending_approval"` and the agent doesn't progress.
+
+**Cause:** One or more tools have `action_behaviour: "always-ask"`, which requires human approval in the UI before execution.
+
+**Fix:**
+
+1. Go to the conversation URL returned in the response to approve/reject the pending tool call
+2. For automated/MCP use, call `relevance_patch_agent` to change the tool's `action_behaviour` to `"never-ask"`
+
+### Duplicate Tasks Created
+
+**Symptom:** The same agent message appears multiple times, creating duplicate conversations.
+
+**Cause:** Re-triggering the agent after a timeout or pending_approval. The original task is still running server-side.
+
+**Fix:** Never re-trigger. Instead, use `relevance_get_task_view` with the original `conversation_id` to check status. The `relevance_trigger_agent` tool returns `timed_out` or `pending_approval` as informational statuses, not errors.
+
 ### Agent Stuck/Not Responding
 
 1. Check task view for errors


### PR DESCRIPTION
## Summary

- **creating.md**: Add OAuth verification step after tool attachment (Step 5)
- **running.md**: Add `pending_approval`/`timed_out` to common issues table, add dry run pattern section
- **troubleshooting.md**: Add "Agent stuck on pending approval" and "Duplicate tasks created" entries

Mirrors skill doc changes from RelevanceAI/relevance-api-node#12778

## Test plan

- [ ] Review skill docs for accuracy
- [ ] Verify tool names match available MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)