### PR TITLE
docs: sync skill docs from nodeapi (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "relevance-ai",
       "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
       "source": "./plugins/relevance-ai",
-      "version": "1.1.0"
+      "version": "1.2.0"
     }
   ]
 }

--- a/plugins/relevance-ai/.claude-plugin/plugin.json
+++ b/plugins/relevance-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relevance-ai",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
   "author": { "name": "Relevance AI", "url": "https://relevanceai.com" },
   "homepage": "https://relevanceai.com",

--- a/plugins/relevance-ai/skills/managing-relevance-agents/SKILL.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/SKILL.md
@@ -21,22 +21,24 @@ Skill for creating, configuring, running, and debugging Relevance AI agents.
 
 ## MCP Tools
 
-| Tool                              | Description                                   |
-| --------------------------------- | --------------------------------------------- |
-| `relevance_list_agents`           | List all agents (supports search)             |
-| `relevance_get_agent`             | Get full agent config                         |
-| `relevance_upsert_agent`          | Create basic agent                            |
-| `relevance_save_agent_draft`      | Save full agent config as draft               |
-| `relevance_publish_agent`         | Publish agent draft to live                   |
-| `relevance_trigger_agent`         | Send message to agent and poll for completion |
-| `relevance_get_agent_tools`       | Get agent's tools with action_ids             |
-| `relevance_attach_tools_to_agent` | Attach tools to an agent                      |
-| `relevance_get_task_view`         | Get conversation details                      |
-| `relevance_list_conversations`    | List agent conversations                      |
-| `relevance_list_agent_triggers`   | List agent triggers                           |
-| `relevance_create_trigger`        | Create trigger                                |
-| `relevance_delete_trigger`        | Delete trigger                                |
-| `relevance_list_oauth_accounts`   | List OAuth accounts for triggers              |
+| Tool                              | Description                                    |
+| --------------------------------- | ---------------------------------------------- |
+| `relevance_list_agents`           | List all agents (supports search)              |
+| `relevance_get_agent`             | Get full agent config                          |
+| `relevance_upsert_agent`          | Create basic agent                             |
+| `relevance_save_agent_draft`      | Save full agent config as draft                |
+| `relevance_publish_agent`         | Publish agent draft to live                    |
+| `relevance_trigger_agent`         | Send message to agent (async, fire-and-forget) |
+| `relevance_trigger_agent_sync`    | Send message and wait for completion           |
+| `relevance_poll_agent_result`     | Poll for agent run status and response         |
+| `relevance_get_agent_tools`       | Get agent's tools with action_ids              |
+| `relevance_attach_tools_to_agent` | Attach tools to an agent                       |
+| `relevance_get_task_view`         | Get conversation details                       |
+| `relevance_list_conversations`    | List agent conversations                       |
+| `relevance_list_agent_triggers`   | List agent triggers                            |
+| `relevance_create_trigger`        | Create trigger                                 |
+| `relevance_delete_trigger`        | Delete trigger                                 |
+| `relevance_list_oauth_accounts`   | List OAuth accounts for triggers               |
 
 ## Critical Rules
 

--- a/plugins/relevance-ai/skills/managing-relevance-agents/phantom-tools.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/phantom-tools.md
@@ -244,3 +244,14 @@ If an agent was published to the marketplace with phantom tools already leaked i
 ### `params_schema` Is Valid — Don't Strip It
 
 A common mistake when cleaning actions is deleting `params_schema`. This field IS valid on action configs and is used for tool input schemas. Don't remove it.
+
+### Blocked Fields in MCP Plugin
+
+The following agent config fields are **blocked from modification** via `relevance_patch_agent` and `relevance_upsert_agent` because they control phantom tool injection and can cause hard-to-reverse damage if set incorrectly:
+
+- `tags` — controls `tag_agent_conversation` phantom tool. **Not** a general-purpose metadata/labelling field.
+- `custom_metadata` — controls `add_conversation_metadata` / `read_conversation_metadata` phantom tools.
+- `escalations` — controls `escalate_to_manager` phantom tool.
+- `remote_mcp_configs` — controls `mcp_remote_tool_call` phantom tool.
+
+These fields are silently stripped before the patch is applied. To modify them, use the Relevance AI dashboard UI.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/phone-agents.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/phone-agents.md
@@ -1,0 +1,218 @@
+# Phone Agent Best Practices
+
+Reference for building production-grade phone agents on Relevance AI.
+
+## Architecture: The Three-Phase Pattern
+
+Phone agents work best as part of a workforce pipeline, not standalone:
+
+```
+Pre-Call Agent  →  Phone Agent  →  Post-Call Agent
+(research)        (conversation)    (processing)
+```
+
+**Pre-Call Agent** — Front-load everything. CRM lookup, account history, recent interactions, talking points. The phone agent should never pause mid-call to research.
+
+**Phone Agent** — Focused on the live conversation. Receives pre-loaded context as params. Minimal tool calling. Drives a singular outcome (book a meeting, capture intake, triage an incident).
+
+**Post-Call Agent** — Processes the call outcome. CRM updates, summary generation, follow-up task creation. Runs after the call ends.
+
+**When a standalone phone agent is fine:** Simple, single-purpose calls with no pre-research and no post-call integrations.
+
+## Core Design Principles
+
+### 1. Front-Load Context, Minimize Tool Calls
+
+Every tool call during a live call adds latency. The agent says "please hold" and waits.
+
+- Do all research and lookups BEFORE the call in a pre-call agent
+- Pass context into the phone agent via params
+- If tools are unavoidable, make them lightweight and fast (sub-2s response)
+
+### 2. Drive a Singular Action
+
+Each phone agent should drive ONE clear outcome:
+
+- Book a meeting
+- Capture an intake form
+- Triage an incident
+- Verify identity
+- Confirm an appointment
+
+Do not combine multiple objectives. Multi-objective agents lose conversational focus.
+
+### 3. Keep Responses Short
+
+Phone is not chat. People zone out after 8-10 seconds of continuous speech.
+
+- 2-3 sentences per turn maximum
+- Ask ONE question at a time
+- Use verbal acknowledgments: "Got it", "Makes sense", "Right"
+
+## Prompt Engineering for Voice
+
+### Phone Call Experience Guidelines
+
+Every phone agent system prompt should include:
+
+```
+## Phone Call Experience Guidelines
+
+You are in the middle of a live phone call. Speak naturally and conversationally.
+
+Phone call audio may be interrupted by background noise -- ignore it.
+
+If the caller's audio cuts out briefly, wait a moment, then say: "Sorry, I think I lost you for a second -- could you say that last bit again?"
+
+Keep responses concise. 2-3 sentences per turn, then pause for their response.
+
+Use verbal acknowledgements: "mm-hmm", "right", "got it", "makes sense".
+
+If there is a long silence (5+ seconds), gently prompt: "Still with me?" or "Take your time."
+
+Never say "as an AI" unless directly asked. If asked, be honest.
+```
+
+### What to Ban in Prompts
+
+Explicitly prohibit:
+
+- Markdown formatting (bold, headers, bullets) -- the agent may say "asterisk asterisk" aloud
+- Reading JSON or structured data verbatim
+- Em dashes in spoken output
+- Stacking multiple questions in one turn
+- Long monologues (set a sentence limit)
+
+### Text Normalization
+
+Phone agents must speak data naturally:
+
+- Emails: "charlie dot birch at relevance dot ai"
+- Phone numbers: "oh four one two, three four five, six seven eight"
+- Dates: "March nineteenth" not "2026-03-19"
+- Money: "fifteen hundred dollars" not "$1,500"
+- URLs: avoid reading URLs -- offer to send via email/SMS instead
+
+### Conversation Flow Design
+
+Structure prompts around **phases**, not checklists:
+
+```
+Phase 1: Opening (30 seconds)
+- Greeting, introduce yourself, confirm it is a good time
+
+Phase 2: Core Discussion (5-7 minutes)
+- Weave information gathering into natural conversation
+- Do NOT present as a checklist
+
+Phase 3: Closing (30 seconds)
+- Summarise what you heard back for confirmation
+- Explain next steps
+- Thank them
+```
+
+## Voice Configuration
+
+### Voice Providers
+
+**Cartesia Sonic-3** (recommended default)
+
+- Better voice quality, lower cost (~5x cheaper than ElevenLabs)
+- 3-second voice cloning, 15 languages
+- Adjust `speed` param (0.8-1.0): slightly slower for empathetic calls
+
+**ElevenLabs Multilingual V2**
+
+- Wider language support (70+ languages)
+- 30-second voice cloning requirement
+- Better for multilingual deployments
+
+### Transcription (STT)
+
+**Deepgram Nova-3** is recommended:
+
+- Native streaming with sub-300ms latency
+- Multi-language support with built-in diarization
+- 36% lower word error rate with accents/noise vs Whisper
+
+### Runtime Configuration
+
+Key `runtime.phone_call` settings:
+
+| Setting                   | Recommendation                                                             | Why                                       |
+| ------------------------- | -------------------------------------------------------------------------- | ----------------------------------------- |
+| `first_message_mode`      | `agent-speaks-first` (inbound), `agent-generates-first-message` (outbound) | Inbound callers expect immediate greeting |
+| `end_call_tool_enabled`   | `true` always                                                              | Phantom tool for graceful call endings    |
+| `recording_enabled`       | `true` for production (see compliance note below)                          | Required for QA and compliance            |
+| `silence_timeout_seconds` | 30                                                                         | Prevents zombie calls                     |
+
+**Recording note:** Check jurisdictional consent requirements before enabling. See the Compliance section below.
+
+### Agent Settings for Phone
+
+| Setting                    | Recommendation                    | Why                                          |
+| -------------------------- | --------------------------------- | -------------------------------------------- |
+| `autonomy_limit_behaviour` | `terminate-conversation`          | Cannot ask for approval mid-call             |
+| `autonomy_limit`           | 20                                | High enough for full call flow               |
+| `temperature`              | 0 - 0.3                           | Consistent, predictable responses            |
+| `model`                    | `relevance-performance-optimized` | Phone agents need speed                      |
+| `action_behaviour`         | `never-ask`                       | Tools must run without approval during calls |
+
+## Latency Management
+
+Target sub-800ms mouth-to-ear response time.
+
+```
+STT transcription:     200-400ms
+LLM inference:         200-500ms
+TTS synthesis:         75-100ms (first byte)
+Network overhead:      50-100ms
+Total target:          < 800ms per turn
+```
+
+Strategies:
+
+1. **Pre-load all context** -- most impactful
+2. **Use fast, lightweight tools** (sub-2s)
+3. **Use `relevance-performance-optimized` model**
+4. **Filler phrases** for unavoidable pauses: "Let me check that for you"
+5. **Post-call processing** for CRM updates and summaries
+
+## Post-Call Processing
+
+### Silent JSON Extraction
+
+The phone agent's prompt should include:
+
+```
+After the call ends, extract all captured information into a JSON object
+and send it using the {{_actions.tool_id}} tool.
+
+Do NOT read the JSON out loud on the call.
+```
+
+### What to Capture
+
+- Call metadata: status, duration, confidence level
+- Contact info: name, team, role
+- Structured data: whatever the call was designed to capture
+- Conversation summary: 3-5 sentence handoff note
+- Follow-up actions: callback time, tasks created
+
+## Common Pitfalls
+
+1. **Tool-heavy phone agents** -- every tool call is a "please hold" moment
+2. **Multi-objective agents** -- leads to unfocused, poor-quality calls
+3. **No escalation path** -- callers trapped in loops with no way to a human
+4. **Reading structured data aloud** -- JSON/lists spoken verbatim sounds robotic
+5. **Cost-optimized model** -- adds noticeable latency
+6. **Missing post-call processing** -- nothing recorded to CRM
+7. **Instructions in spoken templates** -- parenthetical instructions get read aloud. Use comments (`<!-- -->`) for instructions
+8. **Premature call termination** -- the phantom `end_call_tool` fires on any perceived farewell. Add guardrails: "Only end the call after the full closing sequence is complete"
+
+## Compliance
+
+- **Recording consent:** Check jurisdictional requirements (some require two-party consent). When in doubt, announce recording at call start
+- **AI disclosure:** If asked, always be honest about being AI. Some jurisdictions require proactive disclosure
+- **Outbound calls:** Check applicable regulations for AI-generated calls. Provide an opt-out mechanism
+- **Data retention:** Follow org retention and access control policies for stored transcripts

--- a/plugins/relevance-ai/skills/managing-relevance-agents/running.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/running.md
@@ -4,36 +4,40 @@ How to trigger agents, manage conversations, and view results.
 
 ## Triggering Agents
 
-### Choosing Sync vs Async
+### Trigger Agent
 
-| Method | Use when | Timeout |
-|--------|----------|---------|
-| `relevance_trigger_agent` | Quick agents (<60s): simple lookups, single tool calls | 120s (MCP transport limit) |
-| `relevance_trigger_agent_async` + `relevance_poll_agent_result` | Long-running agents: multi-tool chains, web scraping, file generation, workforce stages | No limit |
+Use `relevance_trigger_agent` to send a message. Returns immediately with a `conversation_id`:
 
-**Important**: `relevance_trigger_agent` has a hard 120s transport timeout that cannot be extended. For agents with multiple tool calls (e.g. scrape + enrich + generate + send), always use the async pattern. If a sync trigger times out, **do NOT re-trigger** — the agent is still running server-side. Use `relevance_get_task_view` with the conversation_id to check status.
+```typescript
+const result = await relevance_trigger_agent({
+  agentId: '...',
+  message: 'Research the latest AI developments',
+});
+// Returns { conversation_id } immediately
+// Use relevance_poll_agent_result to check status and get the response
+```
 
-### Sync Trigger (Quick Agents)
+### Synchronous (Wait for Completion)
 
-Use `relevance_trigger_agent` for agents that complete in under ~60s:
+Use `relevance_trigger_agent_sync` to trigger and wait for completion (up to 120s):
+
+```typescript
+const result = await relevance_trigger_agent_sync({
+  agentId: '...',
+  message: 'Research the latest AI developments',
+});
+// Returns { status, response, toolCalls } when done
+```
+
+### Continue Existing Conversation
 
 ```typescript
 relevance_trigger_agent({
   agentId: '...',
-  message: 'Research the latest AI developments',
+  conversationId: 'previous-conversation-id',
+  message: 'Tell me more about transformers',
 });
 ```
-
-### Async Trigger (Long-Running Agents — Recommended)
-
-Use `relevance_trigger_agent_async` then poll with `relevance_poll_agent_result`:
-
-1. Call `relevance_trigger_agent_async` — returns immediately with `conversation_id`
-2. Call `relevance_poll_agent_result` every few seconds until `status` is `completed` or `failed`
-
-### Continue Existing Conversation
-
-Pass `conversation_id` to either trigger method to continue a conversation.
 
 ## Viewing Conversations
 
@@ -138,15 +142,14 @@ const task = await relevance_get_task_view({
 
 ### Common Issues
 
-| Symptom                          | Likely Cause                          | Fix                                                                                         |
-| -------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Agent doesn't use tools          | System prompt unclear                 | Make tool instructions explicit                                                              |
-| Tool execution fails             | Missing project/region                | Add to action config                                                                         |
-| Wrong tool called                | Tool descriptions unclear             | Update action descriptions                                                                   |
-| Slow response                    | Too many tools                        | Remove unused tools                                                                          |
-| `pending_approval` status        | `action_behaviour: "always-ask"`      | Approve in UI, or change to `"never-ask"` for automated use                                  |
-| `timed_out` status               | Agent takes >120s                     | Use `relevance_get_task_view` to poll — do NOT re-trigger                                    |
-| Transport timeout (120s)         | Sync trigger + long-running agent     | Use `relevance_trigger_agent_async` + `relevance_poll_agent_result`                           |
+| Symptom                   | Likely Cause                     | Fix                                                         |
+| ------------------------- | -------------------------------- | ----------------------------------------------------------- |
+| Agent doesn't use tools   | System prompt unclear            | Make tool instructions explicit                             |
+| Tool execution fails      | Missing project/region           | Add to action config                                        |
+| Wrong tool called         | Tool descriptions unclear        | Update action descriptions                                  |
+| Slow response             | Too many tools                   | Remove unused tools                                         |
+| `pending_approval` status | `action_behaviour: "always-ask"` | Approve in UI, or change to `"never-ask"` for automated use |
+| `timed_out` status        | Agent takes >120s                | Use `relevance_get_task_view` to poll — do NOT re-trigger   |
 
 ## URL Patterns
 

--- a/plugins/relevance-ai/skills/managing-relevance-agents/triggers.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/triggers.md
@@ -10,13 +10,14 @@ Triggers **feed the agent's unit of action** — delivering work so the agent ca
 
 Event-driven triggers fire **when something happens**. The external system pushes the event to Relevance AI, and the agent runs immediately in response.
 
-| Trigger             | Event Source                                          | Unit of Action          |
-| ------------------- | ----------------------------------------------------- | ----------------------- |
-| `webhook`           | Salesforce Flow, Zapier, HubSpot workflow, custom app | One record that changed |
-| `gmail` / `outlook` | Incoming email                                        | One email to process    |
-| `slack`             | Slack message                                         | One message/thread      |
-| `unipile_linkedin`  | LinkedIn message                                      | One conversation        |
-| `google_calendar`   | Calendar event                                        | One meeting to prep     |
+| Trigger             | Event Source                                   | Unit of Action          |
+| ------------------- | ---------------------------------------------- | ----------------------- |
+| `custom_webhook`    | Zapier, Make, HubSpot workflow, CRM automation | One record with payload |
+| `webhook`           | Simple HTTP POST from any source               | One request             |
+| `gmail` / `outlook` | Incoming email                                 | One email to process    |
+| `slack`             | Slack message                                  | One message/thread      |
+| `unipile_linkedin`  | LinkedIn message                               | One conversation        |
+| `google_calendar`   | Calendar event                                 | One meeting to prep     |
 
 **Strengths:**
 
@@ -41,14 +42,15 @@ The CRM admin sets up a workflow/flow that fires when a field changes and meets 
 
 ```
 Typeform → Zapier               Relevance AI
-┌──────────────────────┐       ┌──────────────────────┐
-│ New submission        │       │ Webhook trigger       │
-│ → Zap sends POST ────┼─HTTP─>│ → Agent task:         │
-│   with form data      │       │   "Qualify this lead" │
-└──────────────────────┘       └──────────────────────┘
+┌──────────────────────┐       ┌──────────────────────────┐
+│ New submission        │       │ Custom webhook trigger     │
+│ → Zap sends POST ────┼─HTTP─>│ → message_template maps   │
+│   with form data      │       │   payload → Agent task:   │
+│                       │       │   "Qualify this lead"     │
+└──────────────────────┘       └──────────────────────────┘
 ```
 
-No code needed — Zapier's webhook action sends the payload directly to the agent's webhook URL.
+No code needed — Zapier's webhook action sends the payload directly to the agent's `custom_webhook` URL. The `message_template` controls how the payload is passed to the agent.
 
 **Example: Slack message triggers agent**
 
@@ -137,17 +139,18 @@ Is this time-based work (reports, digests, monitoring)?
 
 ## Trigger Types
 
-| Type               | Description         | Use Case                      |
-| ------------------ | ------------------- | ----------------------------- |
-| `gmail`            | Email received      | Email assistant, auto-replies |
-| `outlook`          | Outlook email       | Enterprise email workflows    |
-| `google_calendar`  | Calendar events     | Meeting prep, scheduling      |
-| `slack`            | Slack messages      | Team automation               |
-| `unipile_linkedin` | LinkedIn messages   | Sales outreach                |
-| `unipile_whatsapp` | WhatsApp messages   | Customer support              |
-| `unipile_telegram` | Telegram messages   | Bot automation                |
-| `webhook`          | Custom webhooks     | External integrations         |
-| `recurring`        | Scheduled execution | Daily reports, checks         |
+| Type               | Description                   | Use Case                                       |
+| ------------------ | ----------------------------- | ---------------------------------------------- |
+| `gmail`            | Email received                | Email assistant, auto-replies                  |
+| `outlook`          | Outlook email                 | Enterprise email workflows                     |
+| `google_calendar`  | Calendar events               | Meeting prep, scheduling                       |
+| `slack`            | Slack messages                | Team automation                                |
+| `unipile_linkedin` | LinkedIn messages             | Sales outreach                                 |
+| `unipile_whatsapp` | WhatsApp messages             | Customer support                               |
+| `unipile_telegram` | Telegram messages             | Bot automation                                 |
+| `webhook`          | Simple webhook endpoint       | Basic HTTP POST trigger                        |
+| `custom_webhook`   | Webhook with message template | Zapier, Make, CRM workflows with field mapping |
+| `recurring`        | Scheduled execution           | Daily reports, checks                          |
 
 ## Managing Triggers
 
@@ -309,7 +312,32 @@ relevance_create_trigger({
 });
 ```
 
-### Webhook Trigger
+### Webhook Triggers
+
+There are two webhook trigger types. **Use `custom_webhook` for most integrations** (Zapier, Make, CRM workflows) — it supports message templates and field mapping. Use plain `webhook` only when you need a simple endpoint with no message transformation.
+
+#### Custom Webhook (recommended for Zapier, Make, CRM integrations)
+
+```typescript
+relevance_create_trigger({
+  agentId: '...',
+  triggerType: 'custom_webhook',
+  config: {
+    webhook_name: 'Zapier Webhook', // optional: display name
+    webhook_description: 'Receives form submissions', // optional: description
+    message_template: '{{$}}', // required: template for agent message
+    // Use {{$}} to pass the entire payload, or {{field_name}} for specific fields
+    mapping: {
+      unique_id: '', // optional: jq path for idempotency (e.g. ".data.id")
+      thread_id: '', // optional: jq path for conversation threading (e.g. ".data.thread_id")
+    },
+  },
+});
+```
+
+#### Simple Webhook
+
+Use when you just need a URL to POST to with no message transformation.
 
 ```typescript
 relevance_create_trigger({

--- a/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
@@ -2,6 +2,26 @@
 
 Common issues and fixes for Relevance AI agents.
 
+## Debugging Error Chains
+
+Work backwards from symptoms to root cause. Don't fix symptoms -- fix root causes.
+
+```
+ERROR LOCATION          ACTUAL CAUSE
+Step N: API call        Step 0: Agent/Trigger
+(parameter missing)     (value never passed)
+```
+
+**Common root causes:**
+
+| Symptom                   | Often Actually Caused By                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| API parameter missing     | Agent didn't pass it in tool call                                               |
+| `KeyError: 'transformed'` | Previous Python step errored or returned wrong type                             |
+| Empty string in API call  | Upstream step received empty input                                              |
+| `required property` error | params_schema mismatch in workforce edge                                        |
+| Tool returns empty `{}`   | Output config not mapped (see creating.md "Fixing Auto-Generated Tool Outputs") |
+
 ## Critical Issues
 
 ### `relevance_save_agent_draft` Warns About Empty Actions
@@ -260,18 +280,6 @@ actions: [{
 **Cause:** Re-triggering the agent after a timeout or pending_approval. The original task is still running server-side.
 
 **Fix:** Never re-trigger. Instead, use `relevance_get_task_view` with the original `conversation_id` to check status. The `relevance_trigger_agent` tool returns `timed_out` or `pending_approval` as informational statuses, not errors.
-
-### Transport Timeout (120s) on Sync Trigger
-
-**Symptom:** `relevance_trigger_agent` fails with `timed out awaiting tools/call after 120s`. The agent is still running on the backend but the MCP connection was dropped.
-
-**Cause:** The MCP transport has a hard 120s timeout on tool calls. Agents with multi-tool chains (scrape + enrich + generate + send) routinely exceed this.
-
-**Fix:** Use the async pattern instead:
-
-1. Call `relevance_trigger_agent_async` — returns `conversation_id` immediately
-2. Poll with `relevance_poll_agent_result` until `status` is `completed` or `failed`
-3. **Never re-trigger** after a timeout — the original task is still running
 
 ### Agent Stuck/Not Responding
 

--- a/plugins/relevance-ai/skills/managing-relevance-knowledge/tables.md
+++ b/plugins/relevance-ai/skills/managing-relevance-knowledge/tables.md
@@ -58,6 +58,8 @@ relevance_list_knowledge_rows({
 
 ### With Filters
 
+**Important:** Filter field names require the `data.` prefix because row fields are nested under `data`:
+
 ```
 relevance_list_knowledge_rows({
   knowledge_set: "my-table",
@@ -65,7 +67,7 @@ relevance_list_knowledge_rows({
   page: 1,
   filters: [
     {
-      field: "domain",
+      field: "data.domain",
       filter_type: "exact_match",
       condition_value: "acme.com"
     }

--- a/plugins/relevance-ai/skills/managing-relevance-tools/creating.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/creating.md
@@ -325,17 +325,31 @@ relevance_upsert_tool({
 
 Every tool MUST have a `state_mapping` field that maps input params to template variables. Without this, `{{search_query}}` won't resolve even when the agent passes the parameter.
 
+### How `state_mapping` works
+
+The `state_mapping` connects two things:
+
+- **Keys** = alias names used in `{{template}}` references (these are just plain names, NO prefix)
+- **Values** = JSONPath into the tool's internal state (these DO use `params.` or `steps.` prefixes)
+
+**The `params.` prefix belongs ONLY in state_mapping values, NEVER in params_schema property names:**
+
 ```json
 {
   "params_schema": {
-    "properties": { "search_query": { "type": "string" } }
+    "type": "object",
+    "properties": {
+      "search_query": { "type": "string" }
+    }
   },
   "state_mapping": {
-    "search_query": "params.search_query"
+    "search_query": "params.search_query",
+    "search": "steps.search.output"
   },
   "transformations": {
     "steps": [
       {
+        "name": "search",
         "transformation": "serper_google_search",
         "params": { "search_query": "{{search_query}}" }
       }
@@ -343,6 +357,13 @@ Every tool MUST have a `state_mapping` field that maps input params to template 
   }
 }
 ```
+
+| Where                            | Uses `params.` prefix? | Example                                 |
+| -------------------------------- | ---------------------- | --------------------------------------- |
+| `params_schema` property names   | **NO**                 | `"search_query": { "type": "string" }`  |
+| `state_mapping` keys             | **NO**                 | `"search_query": "params.search_query"` |
+| `state_mapping` values           | **YES**                | `"search_query": "params.search_query"` |
+| `transformations.steps[].params` | **NO**                 | `"search_query": "{{search_query}}"`    |
 
 **CRITICAL:** Do NOT use curly braces in state_mapping values!
 
@@ -352,6 +373,19 @@ Every tool MUST have a `state_mapping` field that maps input params to template 
 
 // CORRECT - no curly braces
 "state_mapping": { "name": "params.name" }
+```
+
+### JS code steps vs non-JS steps
+
+**JS code steps** have native access to a `steps` global object at runtime (e.g., `steps.search.output`), so they can access inter-step data directly without state_mapping. Prefer the native `steps` object over template injection for complex data. Do NOT put inter-step outputs in state_mapping for JS steps -- this creates phantom params the UI flags as missing.
+
+**Non-JS steps** (prompt_completion, api_call, etc.) rely entirely on state_mapping for template resolution. When a non-JS step needs a previous step's output, you MUST add a state_mapping entry:
+
+```json
+"state_mapping": {
+  "query": "params.query",
+  "search_results": "steps.search.output"
+}
 ```
 
 ## Fixing Auto-Generated Tool Outputs
@@ -423,11 +457,35 @@ Then use template substitution: `api_key = '{{_api_key}}'`
 
 ---
 
+## Step Naming Rules
+
+- **Never prefix step names with `steps.`** -- the namespace is added automatically by the template resolver
+- Step names should be plain identifiers: `calc_date`, `fetch_contacts`, `format_output`
+- `steps.` belongs only in REFERENCES: `{{steps.calc_date.output}}` or state_mapping values like `"steps.calc_date.output"`
+- If the UI shows `steps.calc_date` as the output variable, the actual step name is just `calc_date`
+
+```json
+// WRONG - double-prefixed, breaks references
+{ "name": "steps.search", ... }
+
+// CORRECT - plain identifier
+{ "name": "search", ... }
+```
+
+## Template Injection Size Limit
+
+Template injection (`{{steps.stepName.output}}`) has a size limit (~5-10KB). If a previous step returns a large response (e.g., batch API results with HTML bodies), the injection truncates silently, causing `JSON.parse()` to fail.
+
+**Symptoms:** Step reports 0 results even though the API call succeeded. Same API call works in a standalone tool.
+
+**Workaround:** Split into a list tool (returns IDs/metadata only) + a reader tool (reads one record at a time). This keeps each response small enough for template injection.
+
 ## Best Practices
 
-1. **Use descriptive step names** - Makes debugging easier
+1. **Use descriptive step names** - Plain identifiers, never prefix with `steps.`
 2. **Map outputs explicitly** - Don't rely on implicit variable names
 3. **Test incrementally** - Add one step at a time
 4. **Document with prompt_description** - Help AI know when to use the tool
 5. **Handle errors in Python steps** - Add try/catch for robustness
 6. **Validate every tool before attaching to agents** - Test with `relevance_run_tool` to catch empty output issues
+7. **Use backtick template literals in JS steps** - Never use single quotes (`'{{param}}'`), which break with apostrophes in values

--- a/plugins/relevance-ai/skills/managing-relevance-tools/oauth.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/oauth.md
@@ -9,6 +9,14 @@ When a tool needs to access a third-party API that requires OAuth authentication
 1. Add an OAuth account parameter to the tool
 2. Pass the account ID to transformation steps that need it
 
+**Key rules:**
+
+- Never hardcode `oauth_account_id` in tool step params
+- Always make it a top-level `params_schema` input
+- Add to `state_mapping` as `"oauth_account_id": "params.oauth_account_id"`
+- Reference in steps as `{{oauth_account_id}}`
+- Set to "Set Manually" by default (never auto-assign)
+
 ## Define OAuth Parameter
 
 Add a parameter with `content_type: oauth_account` in the metadata:

--- a/plugins/relevance-ai/skills/managing-relevance-tools/transformations.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/transformations.md
@@ -388,6 +388,53 @@ Supports: PDF, Word, CSV, Excel
 | `api_call`                   | `{{response_body}}`   | `{{step.response_body}}`                      |
 | `relevance_api_call`         | `{{response_body}}`   | `{{step.response_body}}` (auth auto-injected) |
 
+## Email Transformations
+
+### send_email (OAuth — Gmail/Outlook)
+
+Sends email through user's Gmail or Outlook via OAuth.
+
+**Critical:** Provider must use the `_oneof_type_` discriminator pattern:
+
+```json
+{
+  "name": "send_email",
+  "transformation": "send_email",
+  "params": {
+    "provider": { "_oneof_type_": "Gmail" },
+    "oauth_account_id": "{{gmail_account}}",
+    "to": ["recipient@example.com"],
+    "subject": "{{subject}}",
+    "body": "{{email_body}}"
+  }
+}
+```
+
+| Param              | Type   | Notes                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------- |
+| `provider`         | object | `{"_oneof_type_": "Gmail"}` or `{"_oneof_type_": "Outlook"}` -- NOT a string |
+| `oauth_account_id` | string | Connected OAuth account ID                                                   |
+| `to`               | array  | MUST be array, not string                                                    |
+| `subject`          | string | Email subject                                                                |
+| `body`             | string | Supports Markdown (auto-rendered to HTML)                                    |
+
+Optional: `cc`, `bcc` (arrays), `thread_id`, `draft` (boolean), `attachments` (filename -> URL map).
+
+### send_email_step (Mailgun — Server-Side)
+
+For internal/agent use. No OAuth needed.
+
+```json
+{
+  "transformation": "send_email_step",
+  "params": {
+    "recipientEmails": ["user@example.com"],
+    "subject": "Subject here",
+    "body": { "html": "<p>HTML body</p>" }
+  }
+}
+```
+
 ## Common Gotchas
 
 ### 1. prompt_completion uses `{{answer}}` NOT `{{text}}`
@@ -528,3 +575,64 @@ output:
       properties:
         hs_timestamp: '{{get_timestamp.timestamp}}'
 ```
+
+### 9. JS code steps: use backtick template literals, NOT single quotes
+
+**Problem:** Single-quoted template literals break when values contain apostrophes.
+
+`{{param}}` is resolved server-side before the JS code runs (string substitution, not JS evaluation), so backticks are safe for this purpose. However, they are not a security boundary — do not use them for untrusted input that could contain backticks or `${...}` syntax.
+
+```javascript
+// WRONG - breaks if param contains an apostrophe (e.g., "O'Brien")
+const name = '{{name}}';
+
+// BETTER - handles apostrophes in values
+const name = `{{name}}`;
+
+// BEST for complex data - use native steps access (no template injection needed)
+const name = steps.previous_step.output.name;
+```
+
+### 10. JS code steps: handle array params that may serialize as strings
+
+When a tool param is typed as `array`, `{{param}}` may serialize as a comma-separated string. Always handle both:
+
+```javascript
+let items = `{{items}}`;
+try {
+  items = JSON.parse(items);
+} catch {
+  items = items
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+```
+
+### 11. Variable shadowing in JS code steps
+
+state_mapping keys are pre-declared by the runtime. Never use `const` or `let` to declare a variable with the same name as a state_mapping key -- it will shadow the injected value.
+
+### 12. `params_schema` must use proper JSON Schema structure
+
+`params_schema` MUST be a valid JSON Schema object with `properties` wrapper:
+
+```json
+// CORRECT
+{
+  "type": "object",
+  "required": ["email"],
+  "properties": {
+    "email": {"type": "string", "title": "Email"}
+  }
+}
+
+// WRONG - flat format, UI cannot render it
+{
+  "email": {"type": "string", "title": "Email"}
+}
+```
+
+### 13. Step-level conditions not supported
+
+The `condition` property on transformation steps returns 422. Handle conditional logic within the steps themselves (e.g., instruct the LLM to return null, or handle in a downstream JS step). Use `if` for conditional steps instead.

--- a/plugins/relevance-ai/skills/relevance-evals/SKILL.md
+++ b/plugins/relevance-ai/skills/relevance-evals/SKILL.md
@@ -28,7 +28,7 @@ Agent Evals provide a systematic way to evaluate AI agent performance against de
 
 **Key Difference:**
 
-- `score_only` uses **agent-level rules** (created via `POST /evals/rules`)
+- `score_only` uses **agent-level rules** (created via `POST /evals/{resource_type}/{resource_id}/rules`)
 - `generate_and_score` uses **test case rules** (expectedOutcomes defined in test cases)
 
 ---
@@ -73,22 +73,22 @@ Agent Evals provide a systematic way to evaluate AI agent performance against de
 ```typescript
 // First, check existing test sets (optional - for reference)
 const testSets = await relevance_api_request({
-  endpoint: `/evals/test-sets/agent/${agentId}`,
+  endpoint: `/evals/agent/${agentId}/test-sets`,
   method: 'GET',
 });
 // Returns: { test_sets: [{ display_id, name, test_case_count, is_default }, ...] }
 
 // ALWAYS create a NEW test set - don't use the default
 const newTestSet = await relevance_api_request({
-  endpoint: `/evals/test-sets/agent/${agentId}`,
+  endpoint: `/evals/agent/${agentId}/test-sets`,
   method: 'POST',
   body: {
     name: 'My Agent Test Suite', // Use a descriptive name
     test_case_ids: [], // Start empty, add test cases in Step 2
   },
 });
-// Returns: { display_id: "..." }
-const testSetId = newTestSet.display_id; // Save this for Step 2
+// Returns: { test_set_id: "..." }
+const testSetId = newTestSet.test_set_id; // Save this for Step 2
 ```
 
 ### Step 2: Create Test Cases
@@ -154,7 +154,7 @@ const { test_cases } = await relevance_api_request({
 
 // Run evaluation with selected test cases
 const evalResult = await relevance_api_request({
-  endpoint: `/evals/agents/${agentId}/conversations`,
+  endpoint: `/evals/agent/${agentId}/evaluate`,
   method: 'POST',
   body: {
     conversation_ids: [], // Empty for generate_and_score
@@ -168,17 +168,13 @@ const evalResult = await relevance_api_request({
 
 ### Step 4: Poll & Read Results
 
-Use two endpoints: `/runs` for per-run details, `/summary` for the overall score.
+Use two endpoints: `POST .../runs` with a `batch_id` filter for per-run details, `GET .../batches/{id}/summary` for the overall score.
 
-> **NOTE:** `GET /evals/runs/{eval_run_id}` does NOT exist. Always use the batch endpoint to get run details.
+1. **Poll summary until complete:** Call `GET /evals/{resource_type}/{resource_id}/batches/{evalBatchId}/summary` until `tasks_evaluated >= total_runs`. Returns `{ tasks_evaluated, total_runs, summary_score, name, rules }`.
 
-1. **Get all runs:** Call `relevance_api_request` with `GET /evals/batches/{evalBatchId}/runs`. Returns `{ runs: EvalRunDetail[], total_count: number }`.
-
-2. **Poll until complete:** Keep calling the runs endpoint until no runs have status `running` or `queued`.
+2. **Get all runs:** Call `POST /evals/{resource_type}/{resource_id}/runs` with body `{ filters: [{ type: "batch_id", batch_id: evalBatchId }] }`. Returns `{ runs: [...], total_count: number }`.
 
 3. **Read results:** Each completed run has `result.rule_results` inline with `rule_name`, `passed`, and `reason` for each rule.
-
-4. **Get summary (optional):** Call `GET /evals/batches/{evalBatchId}/summary` for the overall score. Returns `{ tasks_evaluated, total_runs, summary_score, name, rules }`.
 
 ---
 
@@ -281,19 +277,19 @@ Examples:
 ```typescript
 // List all test sets for an agent
 const { test_sets } = await relevance_api_request({
-  endpoint: `/evals/test-sets/agent/${agentId}`,
+  endpoint: `/evals/agent/${agentId}/test-sets`,
   method: 'GET',
 });
 
 // Delete an old test set (also deletes its test cases)
 await relevance_api_request({
-  endpoint: `/evals/test-sets/${testSetId}`,
+  endpoint: `/evals/agent/${agentId}/test-sets/${testSetId}`,
   method: 'DELETE',
 });
 
 // Update test set name
 await relevance_api_request({
-  endpoint: `/evals/test-sets/${testSetId}`,
+  endpoint: `/evals/agent/${agentId}/test-sets/${testSetId}`,
   method: 'PUT',
   body: { name: 'New Test Set Name' },
 });
@@ -304,8 +300,8 @@ await relevance_api_request({
 When re-running evals, start clean:
 
 1. List existing test cases with `GET /evals/agent/{agentId}/test-cases`
-2. Delete each test case by calling `DELETE /evals/test-cases/{display_id}` for each one
-3. Create a fresh test set with `POST /evals/test-sets/agent/{agentId}`
+2. Delete each test case by calling `DELETE /evals/agent/{agentId}/test-cases/{display_id}` for each one
+3. Create a fresh test set with `POST /evals/agent/{agentId}/test-sets`
 4. Add new test cases to the fresh test set (continue with Step 2 of the workflow)
 
 ---
@@ -318,44 +314,43 @@ Evals use `relevance_api_request` since there are no dedicated MCP tools. The wo
 
 ### Test Case Endpoints
 
-| Method   | Endpoint                             | Description      |
-| -------- | ------------------------------------ | ---------------- |
-| `POST`   | `/evals/agent/{agent_id}/test-cases` | Create test case |
-| `GET`    | `/evals/agent/{agent_id}/test-cases` | List test cases  |
-| `GET`    | `/evals/test-cases/{test_case_id}`   | Get test case    |
-| `PUT`    | `/evals/test-cases/{test_case_id}`   | Update test case |
-| `DELETE` | `/evals/test-cases/{test_case_id}`   | Delete test case |
+| Method   | Endpoint                                                         | Description      |
+| -------- | ---------------------------------------------------------------- | ---------------- |
+| `POST`   | `/evals/agent/{agent_id}/test-cases`                             | Create test case |
+| `GET`    | `/evals/agent/{agent_id}/test-cases`                             | List test cases  |
+| `GET`    | `/evals/{resource_type}/{resource_id}/test-cases/{test_case_id}` | Get test case    |
+| `PUT`    | `/evals/{resource_type}/{resource_id}/test-cases/{test_case_id}` | Update test case |
+| `DELETE` | `/evals/{resource_type}/{resource_id}/test-cases/{test_case_id}` | Delete test case |
 
 ### Test Set Endpoints
 
-| Method   | Endpoint                            | Description     |
-| -------- | ----------------------------------- | --------------- |
-| `POST`   | `/evals/test-sets/agent/{agent_id}` | Create test set |
-| `GET`    | `/evals/test-sets/agent/{agent_id}` | List test sets  |
-| `PUT`    | `/evals/test-sets/{test_set_id}`    | Update test set |
-| `DELETE` | `/evals/test-sets/{test_set_id}`    | Delete test set |
+| Method   | Endpoint                                                       | Description     |
+| -------- | -------------------------------------------------------------- | --------------- |
+| `POST`   | `/evals/{resource_type}/{resource_id}/test-sets`               | Create test set |
+| `GET`    | `/evals/{resource_type}/{resource_id}/test-sets`               | List test sets  |
+| `PUT`    | `/evals/{resource_type}/{resource_id}/test-sets/{test_set_id}` | Update test set |
+| `DELETE` | `/evals/{resource_type}/{resource_id}/test-sets/{test_set_id}` | Delete test set |
 
 ### Evaluation Endpoints
 
-| Method   | Endpoint                                                 | Description                        |
-| -------- | -------------------------------------------------------- | ---------------------------------- |
-| `POST`   | `/evals/agents/{agent_id}/conversations`                 | Trigger evaluation                 |
-| `GET`    | `/evals/batches/{eval_batch_id}/runs`                    | Get all runs with full details     |
-| `GET`    | `/evals/batches/{eval_batch_id}/summary`                 | Get batch summary score            |
-| `POST`   | `/evals/agents/{agent_id}/runs`                          | List runs for agent (with filters) |
-| `POST`   | `/evals/runs/{eval_run_id}/cancel`                       | Cancel a specific run              |
-| `POST`   | `/evals/batches/{eval_batch_id}/cancel`                  | Cancel all runs in a batch         |
-| `GET`    | `/evals/resources/{resource_type}/{resource_id}/batches` | List batches for a resource        |
-| `DELETE` | `/evals/batches/{eval_batch_id}`                         | Delete batch                       |
+| Method   | Endpoint                                                               | Description                 |
+| -------- | ---------------------------------------------------------------------- | --------------------------- |
+| `POST`   | `/evals/{resource_type}/{resource_id}/evaluate`                        | Trigger evaluation          |
+| `POST`   | `/evals/{resource_type}/{resource_id}/runs`                            | List runs (filter by batch) |
+| `GET`    | `/evals/{resource_type}/{resource_id}/batches/{eval_batch_id}/summary` | Get batch summary score     |
+| `POST`   | `/evals/{resource_type}/{resource_id}/runs/{eval_run_id}/cancel`       | Cancel a specific run       |
+| `POST`   | `/evals/{resource_type}/{resource_id}/batches/{eval_batch_id}/cancel`  | Cancel all runs in a batch  |
+| `GET`    | `/evals/{resource_type}/{resource_id}/batches`                         | List batches for a resource |
+| `DELETE` | `/evals/{resource_type}/{resource_id}/batches/{eval_batch_id}`         | Delete batch                |
 
-### Agent-Level Rule Endpoints (for score_only mode)
+### Resource-Level Rule Endpoints (for score_only mode)
 
-| Method   | Endpoint                      | Description |
-| -------- | ----------------------------- | ----------- |
-| `POST`   | `/evals/rules`                | Create rule |
-| `GET`    | `/evals/rules/{agent_id}`     | List rules  |
-| `PATCH`  | `/evals/rules/{eval_rule_id}` | Update rule |
-| `DELETE` | `/evals/rules/{eval_rule_id}` | Delete rule |
+| Method   | Endpoint                                                    | Description |
+| -------- | ----------------------------------------------------------- | ----------- |
+| `POST`   | `/evals/{resource_type}/{resource_id}/rules`                | Create rule |
+| `GET`    | `/evals/{resource_type}/{resource_id}/rules`                | List rules  |
+| `PATCH`  | `/evals/{resource_type}/{resource_id}/rules/{eval_rule_id}` | Update rule |
+| `DELETE` | `/evals/{resource_type}/{resource_id}/rules/{eval_rule_id}` | Delete rule |
 
 ## Writing Effective Rules
 
@@ -384,7 +379,7 @@ Rules are evaluated by an LLM judge. Write rules that are:
 
 This happens when using `score_only` mode without agent-level rules.
 
-- **Solution:** Either create agent-level rules first with `POST /evals/rules`, or use `generate_and_score` with test cases.
+- **Solution:** Either create agent-level rules first with `POST /evals/{resource_type}/{resource_id}/rules`, or use `generate_and_score` with test cases.
 
 ### "scenario_ids are required when type is 'generate_and_score'"
 
@@ -429,9 +424,9 @@ The LLM judge can't determine pass/fail clearly.
   eval_run_id: string;
   status: "queued" | "running" | "completed" | "failed";
   task_name: string;                    // Test case name
-  conversation_display_id: string;      // Generated conversation ID
-  agent_version_display_id?: string;    // Agent version used
-  test_case_display_id?: string;        // Test case ID (generate_and_score only)
+  resource_execution_id: string;        // Generated conversation ID
+  resource_version_id?: string;         // Agent version used
+  test_case_id?: string;                // Test case ID (generate_and_score only)
   error_message?: string;               // Present when status is "failed"
   debug_info?: object;
   result?: {                            // Present when status is "completed"
@@ -446,16 +441,18 @@ The LLM judge can't determine pass/fail clearly.
 }
 ```
 
-### GET /evals/batches/:id/runs Response
+### POST /evals/:resource_type/:resource_id/runs Response
 
 ```typescript
 {
-  runs: EvalRunDetail[];        // Full details for each run
+  runs: Array<{...}>;              // Full details for each run (see API reference)
   total_count: number;
+  page: number;
+  page_size: number;
 }
 ```
 
-### GET /evals/batches/:id/summary Response
+### GET /evals/:resource_type/:resource_id/batches/:id/summary Response
 
 ```typescript
 {

--- a/plugins/relevance-ai/skills/relevance-evals/api-reference.md
+++ b/plugins/relevance-ai/skills/relevance-evals/api-reference.md
@@ -4,14 +4,15 @@ Complete API reference for all evaluation endpoints.
 
 ## Evaluation Execution
 
-### POST /evals/agents/:agent_id/conversations
+### POST /evals/:resource_type/:resource_id/evaluate
 
-Trigger an evaluation run for an agent.
+Trigger an evaluation run for a resource. Currently only `agent` is supported; `workforce` support is coming soon.
 
 **Path Parameters:**
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `agent_id` | string | Yes | The agent display ID |
+| `resource_type` | 'agent' \| 'workforce' | Yes | Resource type (only `agent` currently supported; `workforce` coming soon) |
+| `resource_id` | string | Yes | Resource display ID |
 
 **Request Body:**
 
@@ -21,8 +22,12 @@ Trigger an evaluation run for an agent.
   evaluation_run_name: string;          // Required - name for this evaluation batch
   type?: 'score_only' | 'generate_and_score';  // Default: 'score_only'
   scenario_ids?: string[];              // Required when type is 'generate_and_score'
+  test_set_id?: string;                 // Alternative to scenario_ids - use a test set
   active_version_id?: string;           // Optional - specific agent version to evaluate
   agent_override?: object;              // Optional - override agent config (max 10KB)
+  workforce_task_ids?: string[];        // Not yet supported — workforce evals coming soon
+  tool_simulation_config?: object;      // Optional - tool simulation configuration
+  rule_ids?: string[];                  // Optional - specific rule IDs to evaluate against
 }
 ```
 
@@ -54,7 +59,7 @@ Create a new test case.
 **Path Parameters:**
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `resource_type` | 'agent' \| 'workforce' | Yes | Resource type |
+| `resource_type` | 'agent' \| 'workforce' | Yes | Resource type (only `agent` currently supported; `workforce` coming soon) |
 | `resource_id` | string | Yes | Resource display ID |
 
 **Query Parameters:**
@@ -123,7 +128,7 @@ List all test cases for a resource.
 
 ---
 
-### GET /evals/test-cases/:test_case_id
+### GET /evals/:resource_type/:resource_id/test-cases/:test_case_id
 
 Get a specific test case by ID.
 
@@ -131,7 +136,7 @@ Get a specific test case by ID.
 
 ---
 
-### PUT /evals/test-cases/:test_case_id
+### PUT /evals/:resource_type/:resource_id/test-cases/:test_case_id
 
 Update an existing test case.
 
@@ -141,7 +146,7 @@ Update an existing test case.
 
 ---
 
-### DELETE /evals/test-cases/:test_case_id
+### DELETE /evals/:resource_type/:resource_id/test-cases/:test_case_id
 
 Delete a test case.
 
@@ -151,7 +156,7 @@ Delete a test case.
 
 ## Test Set Management
 
-### POST /evals/test-sets/:resource_type/:resource_id
+### POST /evals/:resource_type/:resource_id/test-sets
 
 Create a new test set.
 
@@ -174,7 +179,7 @@ Create a new test set.
 
 ---
 
-### GET /evals/test-sets/:resource_type/:resource_id
+### GET /evals/:resource_type/:resource_id/test-sets
 
 List all test sets for a resource.
 
@@ -196,7 +201,7 @@ List all test sets for a resource.
 
 ---
 
-### PUT /evals/test-sets/:test_set_id
+### PUT /evals/:resource_type/:resource_id/test-sets/:test_set_id
 
 Update a test set name.
 
@@ -210,7 +215,7 @@ Update a test set name.
 
 ---
 
-### DELETE /evals/test-sets/:test_set_id
+### DELETE /evals/:resource_type/:resource_id/test-sets/:test_set_id
 
 Delete a test set.
 
@@ -221,23 +226,22 @@ Delete a test set.
 
 ---
 
-## Agent-Level Rule Management
+## Resource-Level Rule Management
 
 Used for `score_only` evaluations against existing conversations.
 
-### POST /evals/rules
+### POST /evals/:resource_type/:resource_id/rules
 
-Create a rule for an agent.
+Create a rule for a resource.
 
 **Request Body:**
 
 ```typescript
 {
-  agent_id: string;         // Agent display ID
   user_definition: {
     name: string;           // Rule name
     rule: string;           // Natural language evaluation criterion
-    display_id?: string;    // Optional custom display ID
+    rule_id?: string;       // Optional custom rule ID
   };
 }
 ```
@@ -252,9 +256,9 @@ Create a rule for an agent.
 
 ---
 
-### GET /evals/rules/:agent_id
+### GET /evals/:resource_type/:resource_id/rules
 
-List all rules for an agent.
+List all rules for a resource.
 
 **Response:**
 
@@ -263,7 +267,7 @@ List all rules for an agent.
   rules: Array<{
     name: string;
     rule: string;
-    display_id: string;
+    rule_id: string;
     created_at: string;
   }>;
 }
@@ -271,7 +275,7 @@ List all rules for an agent.
 
 ---
 
-### PATCH /evals/rules/:eval_rule_id
+### PATCH /evals/:resource_type/:resource_id/rules/:eval_rule_id
 
 Update a rule.
 
@@ -282,14 +286,14 @@ Update a rule.
   user_definition: {
     name: string;
     rule: string;
-    display_id?: string;
+    rule_id?: string;
   };
 }
 ```
 
 ---
 
-### DELETE /evals/rules/:eval_rule_id
+### DELETE /evals/:resource_type/:resource_id/rules/:eval_rule_id
 
 Delete a rule (soft delete).
 
@@ -297,7 +301,7 @@ Delete a rule (soft delete).
 
 ## Batch Management
 
-### GET /evals/resources/:resource_type/:resource_id/batches
+### GET /evals/:resource_type/:resource_id/batches
 
 List all evaluation batches for a resource.
 
@@ -315,15 +319,25 @@ List all evaluation batches for a resource.
 
 ---
 
-### GET /evals/batches/:eval_batch_id/runs
+### POST /evals/:resource_type/:resource_id/runs
 
-Get all runs with full details for a batch. This is the primary endpoint for reading eval results.
+List eval runs for a resource with filtering and pagination. This is the primary endpoint for reading eval results.
 
-**Query Parameters:**
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `page` | string | No | Page number |
-| `page_size` | string | No | Results per page |
+**Request Body:**
+
+```typescript
+{
+  page?: number;                         // Page number (1-based)
+  page_size?: number;                    // 1-100
+  filters: Array<{
+    type: 'batch_id';
+    batch_id: string;                    // Batch display ID
+  }>;
+  sort?: {
+    direction?: 'asc' | 'desc';         // Default: 'desc'
+  };
+}
+```
 
 **Response:**
 
@@ -331,11 +345,18 @@ Get all runs with full details for a batch. This is the primary endpoint for rea
 {
   runs: Array<{
     eval_run_id: string;
-    status: 'queued' | 'running' | 'completed' | 'failed';
+    status:
+      | 'queued'
+      | 'dispatched'
+      | 'running'
+      | 'completed'
+      | 'failed'
+      | 'cancelled';
     task_name: string;
-    conversation_display_id: string;
-    agent_version_display_id?: string;
-    test_case_display_id?: string;
+    resource_type: 'agent' | 'workforce';
+    resource_execution_id: string;
+    resource_version_id?: string;
+    test_case_id?: string;
     error_message?: string;
     debug_info?: object;
     result?: {
@@ -350,12 +371,14 @@ Get all runs with full details for a batch. This is the primary endpoint for rea
     };
   }>;
   total_count: number;
+  page: number;
+  page_size: number;
 }
 ```
 
 ---
 
-### GET /evals/batches/:eval_batch_id/summary
+### GET /evals/:resource_type/:resource_id/batches/:eval_batch_id/summary
 
 Get summary info for a batch (overall score, rule definitions).
 
@@ -377,7 +400,7 @@ Get summary info for a batch (overall score, rule definitions).
 
 ---
 
-### POST /evals/runs/:eval_run_id/cancel
+### POST /evals/:resource_type/:resource_id/runs/:eval_run_id/cancel
 
 Cancel a specific eval run.
 
@@ -392,7 +415,7 @@ Cancel a specific eval run.
 
 ---
 
-### POST /evals/batches/:eval_batch_id/cancel
+### POST /evals/:resource_type/:resource_id/batches/:eval_batch_id/cancel
 
 Cancel all pending and running eval runs in a batch.
 
@@ -408,7 +431,7 @@ Cancel all pending and running eval runs in a batch.
 
 ---
 
-### POST /evals/agents/:agent_id/runs
+### POST /evals/:resource_type/:resource_id/runs
 
 List eval runs for an agent with filtering and pagination.
 
@@ -440,7 +463,7 @@ List eval runs for an agent with filtering and pagination.
 
 ---
 
-### DELETE /evals/batches/:eval_batch_id
+### DELETE /evals/:resource_type/:resource_id/batches/:eval_batch_id
 
 Delete a batch and all its runs.
 
@@ -452,7 +475,7 @@ Delete a batch and all its runs.
 // Enums
 type EvalRunStatus = 'queued' | 'running' | 'completed' | 'failed';
 type EvalRunType = 'score_only' | 'generate_and_score';
-type EvalResourceType = 'agent' | 'workforce';
+type EvalResourceType = 'agent' | 'workforce'; // 'workforce' coming soon
 
 // Rule definition
 interface UserRuleDefinition {
@@ -465,7 +488,7 @@ interface UserRuleDefinition {
 interface EvalRule {
   name: string;
   rule: string;
-  display_id: string;
+  rule_id: string;
   created_at: string;
 }
 
@@ -482,7 +505,7 @@ interface EvalResponse {
 
 // Test case
 interface TestCase {
-  display_id: string;
+  test_case_id: string;
   name: string;
   prompt: string;
   max_turns: number;
@@ -494,7 +517,7 @@ interface TestCase {
 
 // Test set summary
 interface TestSetSummary {
-  display_id: string;
+  test_set_id: string;
   name: string;
   test_case_count: number;
   project_id: string;

--- a/plugins/relevance-ai/skills/relevance-slide-builder/SKILL.md
+++ b/plugins/relevance-ai/skills/relevance-slide-builder/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: relevance-slide-builder
+description: Manages slideshows, slideshow templates, slideshow versions, and brand kits in Relevance AI. Use when creating presentations, managing brand assets, exporting slides, or working with slide templates.
+---
+
+# Slide Builder Skill
+
+Skill for managing the Relevance AI slide builder — brand kits, slideshows, templates, and versions.
+
+## Overview
+
+The slide builder lets you create and manage HTML-based presentations programmatically:
+
+- **Brand Kits**: Colors, fonts, logos, tone, and slide instructions that define a visual identity
+- **Slideshows**: Collections of HTML slides with ordering and public/private visibility
+- **Templates**: Reusable slideshow snapshots that can be cloned
+- **Versions**: Automatic version history for slideshows with restore capability
+- **Export**: Generate PDFs or images from slideshows
+
+## No Dedicated MCP Tools
+
+The slide builder uses `relevance_api_request` since there are no dedicated MCP tools. All examples below use this approach.
+
+---
+
+## Brand Kits
+
+Brand kits store visual identity settings — colors, fonts, logos, tone, and instructions for slide generation.
+
+### List Brand Kits
+
+```typescript
+const { branding_kits } = await relevance_api_request({
+  endpoint: '/branding_kits',
+  method: 'GET',
+});
+```
+
+### Create Brand Kit
+
+```typescript
+const { branding_kit_id } = await relevance_api_request({
+  endpoint: '/branding_kits',
+  method: 'POST',
+  body: {
+    name: 'Corporate Brand',
+    colors: [
+      { hexcode: '#1A1A2E', description: 'Primary dark' },
+      { hexcode: '#FFD700', description: 'Accent gold' },
+    ],
+    logos: [{ url: 'https://example.com/logo.png', description: 'Main logo' }],
+    inspiration_photos: [
+      { url: 'https://example.com/photo.jpg', description: 'Hero image' },
+    ],
+    heading: { family: 'Inter', size: 48 },
+    title: { family: 'Inter', size: 36 },
+    subtitle: { family: 'Inter', size: 24 },
+    body: { family: 'Inter', size: 16 },
+    brand_tone: 'Professional, confident, modern',
+    brand_voice: 'Clear, direct, authoritative',
+    slide_instructions:
+      'Use clean layouts with ample whitespace. Accent color for CTAs only.',
+  },
+});
+```
+
+### Get Brand Kit
+
+```typescript
+const kit = await relevance_api_request({
+  endpoint: `/branding_kit/${brandingKitId}`,
+  method: 'GET',
+});
+```
+
+### Update Brand Kit
+
+Partial update — only provided fields are changed.
+
+```typescript
+await relevance_api_request({
+  endpoint: `/branding_kits/${brandingKitId}`,
+  method: 'PUT',
+  body: {
+    name: 'Updated Brand',
+    brand_tone: 'Friendly and approachable',
+  },
+});
+```
+
+### Delete Brand Kit
+
+```typescript
+await relevance_api_request({
+  endpoint: `/branding_kits/${brandingKitId}`,
+  method: 'DELETE',
+});
+```
+
+### Generate Brand Kit from Images (AI)
+
+Analyzes 1-10 images to extract colors, fonts, and brand elements automatically.
+
+```typescript
+const generatedKit = await relevance_api_request({
+  endpoint: '/branding_kits/generate',
+  method: 'POST',
+  body: {
+    image_urls: [
+      'https://example.com/screenshot1.png',
+      'https://example.com/screenshot2.png',
+    ],
+  },
+});
+// Returns a full BrandingKit object with extracted colors, fonts, tone, etc.
+```
+
+---
+
+## Slideshows
+
+Slideshows are ordered collections of HTML slides.
+
+### Create Slideshow
+
+Each slide is an HTML string keyed by a slide ID. The `order` array controls presentation order.
+
+```typescript
+const { slideshow_id } = await relevance_api_request({
+  endpoint: '/slide_show',
+  method: 'POST',
+  body: {
+    content: {
+      'slide-1': '<html><body><h1>Title Slide</h1></body></html>',
+      'slide-2':
+        '<html><body><h1>Key Points</h1><ul><li>Point A</li></ul></body></html>',
+    },
+    order: ['slide-1', 'slide-2'],
+  },
+});
+```
+
+> **Tip:** Each slide is a full HTML document. Use inline `<style>` tags for styling. Google Fonts via `@import url(...)` in a `<style>` block work well.
+
+### Get Slideshow
+
+```typescript
+const slideshow = await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}`,
+  method: 'GET',
+});
+// Returns: { slideshow_id, content, order, public, most_recent_conversation_id? }
+```
+
+### List Slideshows
+
+```typescript
+const { slideshows } = await relevance_api_request({
+  endpoint: '/slide_show?page=1&page_size=20',
+  method: 'GET',
+});
+// Each item: { slideshow_id, first_slide_html, most_recent_conversation_id? }
+```
+
+### Reorder Slides
+
+Must include all existing slide IDs in the new order.
+
+```typescript
+const { order } = await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}/reorder`,
+  method: 'POST',
+  body: { slide_order: ['slide-2', 'slide-1'] },
+});
+```
+
+### Update Visibility
+
+```typescript
+await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}/visibility`,
+  method: 'PATCH',
+  body: { public: true },
+});
+```
+
+### Export Slideshow
+
+Export as PDF or individual images. Returns temporary download URLs.
+
+```typescript
+const { temporary_download_urls } = await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}/export`,
+  method: 'POST',
+  body: {
+    type: 'pdf_standard', // or 'pdf_images' or 'images'
+    // slide_ids: ['slide-1'], // Optional — omit to export all slides
+  },
+});
+```
+
+| Export Type    | Description                                        |
+| -------------- | -------------------------------------------------- |
+| `pdf_standard` | Standard PDF document                              |
+| `pdf_images`   | PDF built from slide screenshots (higher fidelity) |
+| `images`       | Individual PNG files per slide                     |
+
+---
+
+## Slideshow Templates
+
+Templates are saved snapshots of slideshows that can be reused.
+
+### List Templates
+
+```typescript
+const { templates } = await relevance_api_request({
+  endpoint: '/slide_show_template',
+  method: 'GET',
+});
+```
+
+### Create Template from Slideshow
+
+```typescript
+await relevance_api_request({
+  endpoint: '/slide_show_template',
+  method: 'POST',
+  body: { slideshow_id: slideshowId, name: 'Quarterly Report Template' },
+});
+```
+
+### Get Template Content
+
+```typescript
+const template = await relevance_api_request({
+  endpoint: `/slide_show_template/${templateId}/content`,
+  method: 'GET',
+});
+// Returns: { slideshow_template_id, name?, content, order }
+```
+
+### Update Template Name
+
+```typescript
+await relevance_api_request({
+  endpoint: `/slide_show_template/${templateId}`,
+  method: 'PATCH',
+  body: { name: 'New Template Name' },
+});
+```
+
+### Delete Template
+
+```typescript
+await relevance_api_request({
+  endpoint: `/slide_show_template/${templateId}`,
+  method: 'DELETE',
+});
+```
+
+---
+
+## Slideshow Versions
+
+Slideshows automatically track versions. You can list, inspect, and restore previous versions.
+
+### List Versions
+
+```typescript
+const { versions } = await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}/versions`,
+  method: 'GET',
+});
+// Each: { id, display_id, name?, trigger_message_id?, created_at, slide_count }
+```
+
+### Get Version Content
+
+```typescript
+const version = await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}/versions/${versionDisplayId}`,
+  method: 'GET',
+});
+// Returns: { id, display_id, name?, content, slide_order, created_at }
+```
+
+### Restore Version
+
+```typescript
+const { success } = await relevance_api_request({
+  endpoint: `/slide_show/${slideshowId}/versions/${versionDisplayId}/restore`,
+  method: 'POST',
+});
+```
+
+---
+
+## API Reference
+
+### Brand Kit Endpoints
+
+| Method   | Endpoint                          | Description                         |
+| -------- | --------------------------------- | ----------------------------------- |
+| `GET`    | `/branding_kits`                  | List all brand kits                 |
+| `POST`   | `/branding_kits`                  | Create brand kit                    |
+| `GET`    | `/branding_kit/:branding_kit_id`  | Get brand kit                       |
+| `PUT`    | `/branding_kits/:branding_kit_id` | Update brand kit                    |
+| `DELETE` | `/branding_kits/:branding_kit_id` | Delete brand kit                    |
+| `POST`   | `/branding_kits/generate`         | Generate brand kit from images (AI) |
+
+### Slideshow Endpoints
+
+| Method  | Endpoint                               | Description            |
+| ------- | -------------------------------------- | ---------------------- |
+| `POST`  | `/slide_show`                          | Create slideshow       |
+| `GET`   | `/slide_show`                          | List user's slideshows |
+| `GET`   | `/slide_show/:slideshow_id`            | Get slideshow          |
+| `POST`  | `/slide_show/:slideshow_id/reorder`    | Reorder slides         |
+| `PATCH` | `/slide_show/:slideshow_id/visibility` | Update visibility      |
+| `POST`  | `/slide_show/:slideshow_id/export`     | Export as PDF/images   |
+
+### Template Endpoints
+
+| Method   | Endpoint                           | Description                    |
+| -------- | ---------------------------------- | ------------------------------ |
+| `GET`    | `/slide_show_template`             | List templates                 |
+| `POST`   | `/slide_show_template`             | Create template from slideshow |
+| `GET`    | `/slide_show_template/:id/content` | Get template content           |
+| `PATCH`  | `/slide_show_template/:id`         | Update template name           |
+| `DELETE` | `/slide_show_template/:id`         | Delete template                |
+
+### Version Endpoints
+
+| Method | Endpoint                                       | Description         |
+| ------ | ---------------------------------------------- | ------------------- |
+| `GET`  | `/slide_show/:id/versions`                     | List versions       |
+| `GET`  | `/slide_show/:id/versions/:version_id`         | Get version content |
+| `POST` | `/slide_show/:id/versions/:version_id/restore` | Restore version     |
+
+## Brand Kit Schema
+
+```typescript
+{
+  branding_kit_id: string;
+  name: string;
+  colors: Array<{ hexcode: string; description?: string }>;
+  logos: Array<{ url: string; description?: string }>;
+  inspiration_photos: Array<{ url: string; description?: string }>;
+  heading: { family?: string; size?: number };
+  title: { family?: string; size?: number };
+  subtitle: { family?: string; size?: number };
+  subheading: { family?: string; size?: number };
+  section_header: { family?: string; size?: number };
+  body: { family?: string; size?: number };
+  brand_tone: string;
+  brand_voice: string;
+  slide_instructions: string;
+  created_at: string;
+  updated_at: string;
+}
+```


### PR DESCRIPTION
## Summary

- **Synced 13 skill doc files** from nodeapi monorepo source of truth (`packages/relevance-skills/skills/`)
- **New files:** `phone-agents.md` (voice agent guide), `relevance-slide-builder/SKILL.md` (new skill)
- **Updated files:** triggers refactored with `custom_webhook` type, evals API reference with structured output/polling, tool creation validation rules, troubleshooting error chains, transformation docs expanded with OAuth/API-key patterns
- **Version bump:** 1.1.0 → 1.2.0 in both `plugin.json` and `marketplace.json`

## Key changes

- **Triggers refactor:** restructured with `custom_webhook` type, webhook URL retrieval, and per-trigger-type sections
- **Phone agents guide:** new doc covering voice configuration, latency optimization, and prompting patterns
- **Slide builder skill:** new skill for building slide decks via Relevance AI
- **Evals API updates:** structured output mode, polling patterns, and updated endpoint references
- **Tool creation validation:** input schema field name validation rules to prevent mismatches
- **Troubleshooting:** error chain patterns and self-improvement reporting mentions
- **Transformations:** expanded docs with OAuth and API-key transformation patterns

## Test plan

- [ ] Verify plugin installs correctly at v1.2.0
- [ ] Confirm all skill files are present and readable
- [ ] Validate `diff -rq` between nodeapi source and plugin target shows no differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)