### PR TITLE
sync: add MCP bug reporting skill and references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "relevance-ai",
       "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
       "source": "./plugins/relevance-ai",
-      "version": "1.2.0"
+      "version": "1.3.0"
     }
   ]
 }

--- a/plugins/relevance-ai/.claude-plugin/plugin.json
+++ b/plugins/relevance-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relevance-ai",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
   "author": { "name": "Relevance AI", "url": "https://relevanceai.com" },
   "homepage": "https://relevanceai.com",

--- a/plugins/relevance-ai/skills/managing-relevance-agents/SKILL.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/SKILL.md
@@ -187,3 +187,7 @@ https://app.relevanceai.com/agents/{region}/{project}/{agentId}/{taskId}
 # Clone link
 https://app.relevanceai.com/form/{region}/{project}/clone/agent/{agentId}
 ```
+
+## Reporting Issues
+
+If you encounter bugs, skill gaps, or UX friction while managing agents, submit a report via `POST /bugs/submit` using `relevance_api_request`. See [report-bugs.md](report-bugs.md) for the full schema and guidelines. Use `source: "mcp-auto"` so the engineering team can triage automatically.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/report-bugs.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/report-bugs.md
@@ -1,0 +1,172 @@
+---
+description: Instructs agents to report bugs, skill gaps, and UX friction via the SubmitBugReport API. Use when encountering issues during agent conversations.
+---
+
+# Bug Reporting
+
+When a significant issue is encountered during a conversation, the agent should analyze what went wrong and submit a structured report via the bug report API.
+
+## Reporting Limits
+
+- **Maximum 2 reports per conversation.** After 2 reports, stop reporting — batch remaining issues into a single summary if needed.
+- **Never report failures of the reporting endpoint itself.** If `POST /bugs/submit` fails, do not retry or report the failure — this prevents infinite recursion.
+- **Deduplicate within a conversation.** Before submitting, check whether you already reported an issue with the same `category` + `skill_or_tool` combination. If so, skip it.
+
+## When to Report
+
+Report when ANY of the following occur during a conversation:
+
+- **Bug**: A tool call failed, returned unexpected data, or the agent hit an error
+- **Skill gap**: The agent lacked knowledge or a tool to fulfill the user's request
+- **UX friction**: The user had to repeat themselves, correct the agent, or abandon a task
+- **Feature request**: The user explicitly asked for something the platform doesn't support
+- **Hallucination**: The agent fabricated capabilities, tool names, or configuration options
+
+Do NOT report:
+
+- Successful conversations with no issues
+- User errors unrelated to the platform (e.g. typos in their own data)
+- Issues already reported in the same conversation
+- Failures of the `POST /bugs/submit` endpoint itself
+
+## How to Report
+
+Use the `relevance_api_request` MCP tool to call the `POST /bugs/submit` endpoint.
+
+```typescript
+relevance_api_request({
+  method: 'POST',
+  endpoint: '/bugs/submit',
+  body: {
+    source: 'mcp-auto',
+    region: '<current region>',
+    project: '<current project ID>',
+    message: 'Detailed description of the issue',
+    category: 'bug | skill-gap | ux-friction | feature-request | hallucination',
+    context: {
+      severity: 'low | medium | high | critical',
+      title: 'Short summary (under 100 chars)',
+      suggested_fix: 'Concrete suggestion for how to fix',
+      agent_id: 'agent ID if available',
+      conversation_id: 'conversation/task ID if available',
+      skill_or_tool: 'MCP tool or skill involved',
+    },
+  },
+});
+```
+
+> **Note:** `region` and `project` are required by the API. Use the region and project ID from the current MCP session context (e.g. `relevance_get_project_info`).
+
+### Field Reference
+
+| Field                     | Required | Notes                                                                                                  |
+| ------------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| `source`                  | Yes      | Always `"mcp-auto"` for agent-generated reports                                                        |
+| `region`                  | Yes      | Current region code (e.g. `"bcbe5a"`)                                                                  |
+| `project`                 | Yes      | Current project ID                                                                                     |
+| `message`                 | Yes      | Detailed description: what the user wanted, what happened, what should have happened                   |
+| `category`                | Yes      | One of: `bug`, `skill-gap`, `ux-friction`, `feature-request`, `hallucination`                          |
+| `context.severity`        | Yes      | `critical` = blocks core workflow, `high` = significant friction, `medium` = noticeable, `low` = minor |
+| `context.title`           | Yes      | Short, actionable — like a ticket title                                                                |
+| `context.suggested_fix`   | Yes      | Be specific — name the tool, skill, or code change needed                                              |
+| `context.agent_id`        | No       | Include when the issue is agent-specific                                                               |
+| `context.conversation_id` | No       | The task_id or conversation_id                                                                         |
+| `context.skill_or_tool`   | No       | The specific MCP tool or skill that was involved                                                       |
+
+### Sanitization Rules
+
+Reports are stored persistently. **MUST NOT include:**
+
+- API keys, tokens, passwords, or OAuth secrets
+- Auth headers, session cookies, or bearer tokens
+- Raw PII (emails, phone numbers, addresses) — use `[REDACTED]` placeholders
+- Full stack traces — include only the error class/code and message
+- Raw request/response bodies — summarize the shape and relevant fields only
+
+```typescript
+// WRONG — leaks secrets
+message: 'Tool failed with header Authorization: Bearer sk-abc123...';
+
+// CORRECT — redacted
+message: 'Tool failed with 401 Unauthorized when calling Jira API. Auth header was present but rejected.';
+```
+
+### Writing a Good `message`
+
+The `message` field is the most important part of the report. Structure it clearly so the engineering team can understand and reproduce the issue without follow-up questions.
+
+**Use this format:**
+
+```
+## Summary
+One-sentence description of what went wrong.
+
+## Steps to Reproduce
+1. What the user asked for
+2. What tool/action was attempted
+3. What parameters were used (redact secrets)
+
+## Expected Behavior
+What should have happened.
+
+## Actual Behavior
+What actually happened — include error messages (sanitized), HTTP status codes, or unexpected return values.
+
+## Impact
+What was the consequence — data loss, blocked workflow, user had to work around manually, etc.
+
+## Recommendations
+Concrete suggestions: name the specific tool, endpoint, or code change needed.
+```
+
+**Tips for actionable reports:**
+
+- Lead with the user's intent, not just the error
+- Include the exact MCP tool name and parameters that triggered the issue
+- Note whether a workaround exists and what it is
+- If data was lost or corrupted, describe what changed (before vs after)
+- Be specific in recommendations — "add a list_templates tool" is better than "fix this"
+
+### Example
+
+```typescript
+relevance_api_request({
+  method: 'POST',
+  endpoint: '/bugs/submit',
+  body: {
+    source: 'mcp-auto',
+    region: 'bcbe5a',
+    project: 'a3cd1b1efb8c-4da4-8728-81a8bc7333ca',
+    message:
+      '## Summary\nrelevance_api_request with POST /agents/upsert wiped entire agent config when attempting a partial update.\n\n## Steps to Reproduce\n1. User asked to update only the system_prompt of agent 5f8e0e41\n2. Called relevance_api_request with POST /agents/upsert, body: { agent_id, partial_update: true, system_prompt: "test" }\n3. partial_update: true was silently ignored\n\n## Expected Behavior\nOnly system_prompt should change; other fields (actions, model, knowledge) should be preserved.\n\n## Actual Behavior\nEntire agent config replaced — actions dropped from 2 to 0, system_prompt went from 42K chars to 4 chars, model reset to default.\n\n## Impact\nProduction agent actively processing SDR call transcripts was wiped. Recovered via version rollback.\n\n## Recommendations\n1. Block /agents/upsert from relevance_api_request — use relevance_patch_agent instead\n2. Make partial_update actually work, or reject it with a validation error',
+    category: 'bug',
+    context: {
+      severity: 'critical',
+      title: 'POST /agents/upsert via raw API silently wipes agent config',
+      suggested_fix:
+        'Block /agents/upsert from relevance_api_request allowlist. Dedicated tools (relevance_patch_agent) already handle safe updates with fetch-merge-save pattern.',
+      agent_id: '5f8e0e41-98bf-4068-90ed-2a722fb68466',
+      skill_or_tool: 'relevance_api_request',
+    },
+  },
+});
+```
+
+## Severity Guide
+
+| Severity   | Criteria                                                       | Example                                                   |
+| ---------- | -------------------------------------------------------------- | --------------------------------------------------------- |
+| `critical` | Core workflow completely blocked, data loss, or security issue | Tool execution crashes the agent loop                     |
+| `high`     | Significant user friction, workaround is painful               | Agent can't attach tools — user must do it manually in UI |
+| `medium`   | Noticeable issue but workaround exists                         | Search returns wrong results but user can filter manually |
+| `low`      | Minor inconvenience or cosmetic issue                          | Tool description is confusing but functionality works     |
+
+## Triage Process
+
+Reports submitted via `POST /bugs/submit` are stored server-side and triaged by the engineering team:
+
+1. Filter reports where `source = 'mcp-auto'`
+2. Assess severity and category
+3. Convert actionable reports into Linear tickets
+4. Group related reports to identify patterns
+5. Prioritize based on frequency and severity

--- a/plugins/relevance-ai/skills/managing-relevance-agents/running.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/running.md
@@ -233,3 +233,4 @@ Once verified, switch back to `"never-ask"` for production use.
 4. **Test with diverse inputs** - Don't rely on a single test; use varied inputs to reveal edge cases
 5. **Monitor for timeouts** - Long tool operations may timeout
 6. **Never re-trigger on timeout or pending_approval** - Use `relevance_get_task_view` to poll instead
+7. **Report issues** - If a tool call fails unexpectedly or the agent behaves incorrectly, submit a report via `POST /bugs/submit` (see [report-bugs.md](report-bugs.md))

--- a/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
@@ -418,3 +418,7 @@ const transform = await relevance_get_transformation({
 3. Test tools independently with `relevance_run_tool`
 4. Review OAuth with `relevance_list_oauth_accounts`
 5. Check transformation schemas with `relevance_get_transformation`
+
+## Reporting Issues
+
+If troubleshooting reveals a platform bug, missing capability, or recurring friction point, submit a report via `POST /bugs/submit` using `relevance_api_request`. See [report-bugs.md](report-bugs.md) for the full schema. This feeds directly into the engineering triage pipeline — include the error details and suggested fix so the team can act on it.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/SKILL.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/SKILL.md
@@ -175,3 +175,7 @@ If you accidentally wipe a tool:
 3. `relevance_publish_tool({ toolId: "my-tool" })` — Publish the restored draft
 
 See [versions.md](versions.md) for full details.
+
+## Reporting Issues
+
+If you encounter tool creation failures, transformation errors, or missing capabilities, submit a report via `POST /bugs/submit` using `relevance_api_request`. See the [bug reporting guide](../managing-relevance-agents/report-bugs.md) for the full schema and guidelines.

--- a/plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md
+++ b/plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md
@@ -200,3 +200,7 @@ Then have the orchestrator extract data from the sub-agent's response text. See 
 ✅ Research → Generate → Deliver
 ❌ Research → Deliver → Generate
 ```
+
+## Reporting Issues
+
+If debugging reveals a platform bug, unexpected behavior, or a gap in workforce capabilities, submit a report via `POST /bugs/submit` using `relevance_api_request`. See the [bug reporting guide](../managing-relevance-agents/report-bugs.md) for the full schema. Include the workforce task ID and agent IDs involved so the team can reproduce.


### PR DESCRIPTION
## Summary
- Add new `report-bugs.md` skill file for MCP bug reporting in managing-relevance-agents
- Update 5 existing skill files with "Reporting Issues" sections pointing to the new bug reporting skill:
  - `managing-relevance-agents/SKILL.md`
  - `managing-relevance-agents/running.md`
  - `managing-relevance-agents/troubleshooting.md`
  - `managing-relevance-tools/SKILL.md`
  - `managing-relevance-workforces/debugging.md`

## Test plan
- [x] `diff -r` between source of truth and destination shows zero diffs
- [ ] Verify skills load correctly in the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)