### PR TITLE
sync: MCP draft-first / publish-confirmation skills (v1.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "relevance-ai",
       "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
       "source": "./plugins/relevance-ai",
-      "version": "1.4.0"
+      "version": "1.4.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "relevance-ai",
       "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
       "source": "./plugins/relevance-ai",
-      "version": "1.3.0"
+      "version": "1.4.0"
     }
   ]
 }

--- a/plugins/relevance-ai/.claude-plugin/plugin.json
+++ b/plugins/relevance-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relevance-ai",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
   "author": { "name": "Relevance AI", "url": "https://relevanceai.com" },
   "homepage": "https://relevanceai.com",

--- a/plugins/relevance-ai/.claude-plugin/plugin.json
+++ b/plugins/relevance-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relevance-ai",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Build and manage AI agents, tools, and workforces on Relevance AI",
   "author": { "name": "Relevance AI", "url": "https://relevanceai.com" },
   "homepage": "https://relevanceai.com",

--- a/plugins/relevance-ai/CLAUDE.md
+++ b/plugins/relevance-ai/CLAUDE.md
@@ -56,22 +56,24 @@ https://api-f1db6c.stack.tryrelevance.com/latest/documentation
 
 Most common gotchas at a glance. Full details and examples are in the skill files above.
 
-### Publish Behavior
+### Publish Behavior — Draft-First, Publish-on-Confirm
 
-| Operation                    | Auto-publishes? | Notes                                                                         |
-| ---------------------------- | --------------- | ----------------------------------------------------------------------------- |
-| `relevance_upsert_tool`      | Yes             | `relevance_publish_tool` returns friendly "already published" if called after |
-| `relevance_save_agent_draft` | Yes (default)   | Pass `autoPublish: false` to save draft only                                  |
-| `relevance_create_workforce` | Configurable    | Use `shouldPublish: true` (default)                                           |
+All agent and tool edits save to **DRAFT only**. Nothing goes live until you explicitly call a publish tool, which always shows the user an approval card. Never publish without first asking "want me to publish this?".
 
-### No Partial Updates for Agents
+| Operation                                                                                                    | Saves where? | How to go live                                                |
+| ------------------------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------------------------- |
+| `relevance_create_agent` / `relevance_update_agent` / `relevance_attach_tools_to_agent` / `relevance_update_agent_action` | Draft        | `relevance_publish_agent` (requires user confirmation)        |
+| `relevance_create_tool` / `relevance_update_tool` / `relevance_add_tool_step` / `relevance_update_tool_step` / `relevance_remove_tool_step` / `relevance_move_tool_step` | Draft        | `relevance_publish_tool` (requires user confirmation)         |
+| `relevance_create_workforce`                                                                                 | Configurable | Use `shouldPublish: true` (default)                           |
 
-Tools auto-merge on update. **Agents do NOT** — always fetch first, merge, then save:
+### Partial Updates Are Supported
+
+`relevance_update_agent` deep-merges your patch into the current draft, so you only need to send the fields you want to change. The same applies to `relevance_update_tool`. No need to fetch-merge-save manually.
 
 ```typescript
-const { agent } = await relevance_get_agent({ agentId: 'x' });
-agent.name = 'new';
-await relevance_save_agent_draft({ agentId: 'x', agentConfig: agent });
+await relevance_update_agent({ agent_id: 'x', patch: { name: 'new' } });
+// later, when the user confirms:
+await relevance_publish_agent({ agent_id: 'x' });
 ```
 
 ### `state_mapping` is REQUIRED for Tools

--- a/plugins/relevance-ai/CLAUDE.md
+++ b/plugins/relevance-ai/CLAUDE.md
@@ -94,7 +94,7 @@ Phantom tools are system-injected at runtime from agent settings. Never add them
 
 ### Attaching Tools to Agents
 
-Use `relevance_attach_tools_to_agent` — it handles fetch, merge, save, publish, action ID retrieval, and system prompt injection in one call. Test each tool with `relevance_trigger_tool` first — tools that return empty `{}` need their output config fixed.
+Use `relevance_attach_tools_to_agent` — it handles fetch, merge, save, publish, action ID retrieval, and system prompt injection in one call. Test each tool with `relevance_trigger_tool_async` first — tools that return empty `{}` need their output config fixed.
 
 ### Reserved Variable Prefixes
 
@@ -123,7 +123,7 @@ For backward compatibility, `US_RELEVANCE_*` variants are also supported.
 
 ## Handling Large MCP Tool Outputs
 
-Tools like `relevance_get_task_view` and `relevance_trigger_agent_sync` can return 100KB-500KB+ JSON responses.
+Tools like `relevance_get_agent_task_summary`, `relevance_list_agent_task_messages`, and `relevance_poll_agent_result` can return 100KB-500KB+ JSON responses.
 
 ```bash
 # CORRECT - limit input size FIRST

--- a/plugins/relevance-ai/skills/managing-relevance-agents/SKILL.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: managing-relevance-agents
-description: Manages Relevance AI agents - creating, configuring tools, writing system prompts, setting up triggers, and running conversations. Use when building agents, attaching tools, debugging execution, or viewing agent results.
+description: Manages Relevance AI agents - creating, configuring tools, writing system prompts, setting up triggers, and running tasks. Use when building agents, attaching tools, debugging execution, or viewing agent results.
 ---
 
 # Managing Relevance AI Agents
@@ -14,59 +14,77 @@ Skill for creating, configuring, running, and debugging Relevance AI agents.
 - Creating new agents
 - Attaching tools/actions to agents
 - Writing or updating system prompts
-- Configuring agent memory (persistence across conversations)
+- Configuring agent memory (persistence across tasks)
 - Setting up triggers (email, LinkedIn, webhooks, etc.)
-- Running agent conversations
+- Running agent tasks
 - Debugging agent execution issues
 
 ## MCP Tools
 
-| Tool                              | Description                                    |
-| --------------------------------- | ---------------------------------------------- |
-| `relevance_list_agents`           | List all agents (supports search)              |
-| `relevance_get_agent`             | Get full agent config                          |
-| `relevance_upsert_agent`          | Create basic agent                             |
-| `relevance_save_agent_draft`      | Save full agent config as draft                |
-| `relevance_publish_agent`         | Publish agent draft to live                    |
-| `relevance_trigger_agent`         | Send message to agent (async, fire-and-forget) |
-| `relevance_trigger_agent_sync`    | Send message and wait for completion           |
-| `relevance_poll_agent_result`     | Poll for agent run status and response         |
-| `relevance_get_agent_tools`       | Get agent's tools with action_ids              |
-| `relevance_attach_tools_to_agent` | Attach tools to an agent                       |
-| `relevance_get_task_view`         | Get conversation details                       |
-| `relevance_list_conversations`    | List agent conversations                       |
-| `relevance_list_agent_triggers`   | List agent triggers                            |
-| `relevance_create_trigger`        | Create trigger                                 |
-| `relevance_delete_trigger`        | Delete trigger                                 |
-| `relevance_list_oauth_accounts`   | List OAuth accounts for triggers               |
+| Tool                                 | Description                                                                                                                                                                                                          |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `relevance_list_agents`              | List all agents (supports search)                                                                                                                                                                                    |
+| `relevance_get_agent`                | Get agent config. Defaults to the unpublished draft when one exists; pass `version: "active"` to inspect live. Response includes `viewed_version`, `active_version_id`, `draft_version_id`, `has_unpublished_draft`. |
+| `relevance_create_agent`             | Create a NEW agent — saves to DRAFT only; call `relevance_publish_agent` to make it live                                                                                                                             |
+| `relevance_update_agent`             | Update an existing agent — partial-merge, saves to DRAFT only                                                                                                                                                        |
+| `relevance_attach_tools_to_agent`    | Attach tools to an agent — saves to DRAFT only                                                                                                                                                                       |
+| `relevance_update_agent_action`      | Update per-tool config (action_behaviour, prompt_description, default_values, overrides, etc.) on a single attached tool — saves to DRAFT only                                                                       |
+| `relevance_detach_tools_from_agent`  | Remove one or more attached tools from an agent — saves to DRAFT only                                                                                                                                                |
+| `relevance_publish_agent`            | Publish the current draft to live. Always shows an approval card.                                                                                                                                                    |
+| `relevance_list_agent_versions`      | List version history for an agent                                                                                                                                                                                    |
+| `relevance_get_agent_version`        | Get a specific historical version's config                                                                                                                                                                           |
+| `relevance_restore_agent_version`    | Duplicate a previous version into the current draft slot                                                                                                                                                             |
+| `relevance_trigger_agent`            | Send message to agent (returns conversation_id; pair with `relevance_poll_agent_result`). Defaults to draft when one exists.                                                                                         |
+| `relevance_poll_agent_result`        | Long-poll for agent run status and response (pair with `relevance_trigger_agent`)                                                                                                                                    |
+| `relevance_get_agent_tools`          | Get agent's tools with action_ids. Defaults to the draft when one exists; response includes `viewed_version`.                                                                                                        |
+| `relevance_get_agent_task_summary`   | Get task summary: status, messages, tool calls                                                                                                                                                                       |
+| `relevance_list_agent_tasks`         | List recent tasks for an agent                                                                                                                                                                                       |
+| `relevance_list_agent_task_messages` | List raw messages in an agent task                                                                                                                                                                                   |
+| `relevance_get_agent_task_metadata`  | Get task metadata: status, credits, runtime                                                                                                                                                                          |
+| `relevance_list_agent_triggers`      | List agent triggers                                                                                                                                                                                                  |
+| `relevance_create_trigger`           | Create trigger                                                                                                                                                                                                       |
+| `relevance_delete_trigger`           | Delete trigger                                                                                                                                                                                                       |
+| `relevance_list_oauth_accounts`      | List OAuth accounts for triggers                                                                                                                                                                                     |
+| `relevance_submit_feedback`          | Report a bug or suggest an improvement — call proactively after errors or friction                                                                                                                                   |
+
+## Resource URLs
+
+The following tools return a `url` field in their response pointing directly to the correct page in the Relevance AI app. **Always share this URL with the user immediately after the operation completes.**
+
+| Tool                      | URL points to                |
+| ------------------------- | ---------------------------- |
+| `relevance_create_agent`  | Agent instructions edit page |
+| `relevance_update_agent`  | Agent instructions edit page |
+| `relevance_publish_agent` | Agent instructions edit page |
+| `relevance_trigger_agent` | Agent task page              |
+
+The URL is already constructed with the correct region and project ID — just present it to the user.
 
 ## Critical Rules
+
+### Draft-First Editing — Publish Is Always Explicit
+
+The MCP tools mirror the builder app's draft / publish split. **Every edit saves to a draft. Publishing is always a separate, user-confirmed step.**
+
+- **Creating a new agent** (`relevance_create_agent`): saves to a DRAFT. The new agent has a `draft_version_id` and no `active_version_id` until you call `relevance_publish_agent`. `relevance_trigger_agent` defaults to draft, so the agent is testable as soon as creation returns.
+- **Updating an existing agent** (`relevance_update_agent` or `relevance_attach_tools_to_agent`): saves to a DRAFT. The previously-published "live" version remains untouched until you explicitly publish. `relevance_update_agent` deep-merges your patch into the current draft, so you only need to send the fields you want to change.
+- **Going live**: call `relevance_publish_agent`. This always shows an approval card to the user — even when auto-approve is on. Do not call publish without first asking the user "want me to publish this?" in chat.
+- **Testing the draft**: `relevance_trigger_agent` (and `_sync`) defaults to the draft when one exists, so you can run the in-progress version without affecting production. The response includes `triggered_version` so you can tell the user which version actually ran.
+- **Restoring a previous version**: `relevance_list_agent_versions` to find the version_id, `relevance_get_agent_version` to inspect it, then `relevance_restore_agent_version` to bring it back as a fresh draft (followed by `relevance_publish_agent` to make it live).
+
+#### Reading an agent while a draft exists
+
+`relevance_get_agent` and `relevance_get_agent_tools` default to the unpublished draft when one exists, mirroring the builder app — so the LLM and the user are looking at the same thing. The response's `viewed_version` field tells you what you read (`"draft"`, `"active"`, or a specific `version_id`), alongside `active_version_id`, `draft_version_id`, and `has_unpublished_draft`.
+
+**When `viewed_version` is `"draft"`, say so to the user explicitly** — e.g. "I'm looking at the unpublished draft — there are unsaved changes here that aren't live yet." This matters because anything you propose is rooted in the draft, not the live config; the user needs to know the baseline before approving edits or asking you to publish.
+
+If the user wants to see what's currently live or compare draft vs live, re-fetch with `version: "active"` and narrate the diff. Do not silently mix draft and live config in the same response — pick one and label it.
 
 ### Sub-Agents are DEPRECATED
 
 > ⚠️ **Do NOT add agents to another agent's `actions` array.** This pattern is deprecated.
 >
 > Use **Workforces** instead for multi-agent orchestration. See [Workforce Documentation](../managing-relevance-workforces/SKILL.md).
-
-### NO PARTIAL UPDATES
-
-`relevance_save_agent_draft` does NOT support partial updates. Any field you omit will be WIPED.
-
-```typescript
-// WRONG - wipes system_prompt, actions, etc!
-relevance_save_agent_draft({
-  agentId: 'xxx',
-  agentConfig: { emoji: 'new-emoji' },
-});
-
-// CORRECT - get first, merge, save everything
-const { agent } = await relevance_get_agent({ agentId: 'xxx' });
-relevance_save_agent_draft({
-  agentId: 'xxx',
-  agentConfig: { ...agent, emoji: 'new-emoji' },
-});
-relevance_publish_agent({ agentId: 'xxx' });
-```
 
 ### Actions Require project/region (CRITICAL)
 
@@ -103,33 +121,25 @@ Missing project/region causes cloning failures and tool execution errors.
 
 ### Action IDs for System Prompts (Two-Pass Required!)
 
-If your system prompt references tools via `{{_actions.ACTION_ID}}`, you need **TWO publish cycles**:
+If the agent has any attached tools, the second pass is **required** — weave `{{_actions.<id>}}` references inline into the system_prompt prose where each tool is used. The runtime substitutes each pill for the real function-call name; the prompt editor renders them as clickable pill chips. Plain prose like "use the Google Search tool" produces no pill and gives the LLM a weak tool-selection cue.
 
 ```
-Pass 1: Create agent + attach tools + placeholder prompt → Publish
-Pass 2: Fetch real action IDs → Update prompt with IDs → Publish again
+Pass 1: Create agent + attach tools + placeholder prompt   (saved to draft)
+Pass 2: Fetch real action IDs → Update prompt with pills   (saved to draft)
 ```
 
-**Why?** Action IDs are backend-generated hex strings that only exist AFTER first publish. You can't write the final system prompt until tools are attached and published.
+**Why?** Action IDs are deterministic hex strings derived from action config — they don't exist until tools are attached. After the first draft save, call `relevance_get_agent_tools` (with `version: "draft"`) to read the real `action_id` for each attached tool, or use the `action_id_map` returned by `relevance_attach_tools_to_agent`. Then call `relevance_update_agent` with a system_prompt patch that inserts those IDs inline. Both passes save to draft — publish only after the user has reviewed and confirmed.
 
-```typescript
-// After first publish, get real action IDs:
-const { actionIdMap } = await relevance_get_agent_tools({ agentId });
-// actionIdMap: { "my-tool-studio-id": "3261d8205a334a99" }
-
-// Then update system prompt with real IDs and publish again
-```
-
-**Skip the second pass** if your prompt doesn't use `{{_actions.*}}` references.
+The `## Tool References` block that `relevance_attach_tools_to_agent` auto-appends to the system_prompt stays — it's reference data and a fallback for any tool you don't reference inline. Weaving pills into the prose ABOVE the block is what gives the LLM strong inline tool-selection cues.
 
 See [creating.md - Action IDs](creating.md#action-ids-vs-studio-ids) for full workflow with code examples.
 
 ## Quick Start: Create Agent
 
-1. **Create basic agent:**
+1. **Create basic agent** — saves to a draft (does NOT publish):
 
    ```
-   relevance_upsert_agent({
+   relevance_create_agent({
      name: "Research Assistant",
      description: "Helps research topics",
      system_prompt: "You are a research assistant.\nWhen asked about a topic:\n1. Search for information\n2. Summarize findings"
@@ -139,30 +149,31 @@ See [creating.md - Action IDs](creating.md#action-ids-vs-studio-ids) for full wo
 2. **Get the agent** to see the generated ID:
 
    ```
-   relevance_get_agent({ agentId: "..." })
+   relevance_get_agent({ agent_id: "..." })
    ```
 
-3. **Add tools** — get the full agent config first, then save with actions:
+3. **Add tools** — saves to a draft (does NOT publish):
 
    ```
-   relevance_save_agent_draft({
-     agentId: "...",
-     agentConfig: {
-       ...existingAgent,
-       actions: [{
-         chain_id: "google-search",
-         project: "your-project-id",
-         region: "tool-region",
-         title: "Search Google",
-         action_behaviour: "never-ask"
-       }]
-     }
+   relevance_attach_tools_to_agent({
+     agent_id: "...",
+     tool_ids: ["google-search"],
+     action_behaviour: "never-ask",
    })
    ```
 
-4. **Publish:** `relevance_publish_agent({ agentId: "..." })`
+4. **Test the draft** — trigger uses the draft when one exists:
 
-5. **Test:** `relevance_trigger_agent({ agentId: "...", message: "Research AI trends" })`
+   ```
+   relevance_trigger_agent({ agent_id: "...", message: "Research AI trends" })
+   // Response includes triggered_version: "draft"
+   ```
+
+5. **Publish when the user confirms** — always asks even with auto-approve:
+
+   ```
+   relevance_publish_agent({ agent_id: "..." })
+   ```
 
 ## Reference Files
 
@@ -175,19 +186,21 @@ See [creating.md - Action IDs](creating.md#action-ids-vs-studio-ids) for full wo
 - [running.md](running.md) - Running and testing agents
 - [troubleshooting.md](troubleshooting.md) - Common issues and fixes
 
+For organizing agents into folders, see the [`managing-relevance-folders`](../managing-relevance-folders/SKILL.md) skill.
+
 ## URL Patterns
 
 ```
 # Agent edit page
 https://app.relevanceai.com/agents/{region}/{project}/{agentId}/edit/instructions
 
-# Conversation view
+# Task view
 https://app.relevanceai.com/agents/{region}/{project}/{agentId}/{taskId}
 
 # Clone link
 https://app.relevanceai.com/form/{region}/{project}/clone/agent/{agentId}
 ```
 
-## Reporting Issues
+## Reporting Issues — proactive
 
-If you encounter bugs, skill gaps, or UX friction while managing agents, submit a report via `POST /bugs/submit` using `relevance_api_request`. See [report-bugs.md](report-bugs.md) for the full schema and guidelines. Use `source: "mcp-auto"` so the engineering team can triage automatically.
+If anything goes wrong or feels missing while managing agents, **call `relevance_submit_feedback` immediately** — do not ask the user for permission first. One tool covers bugs, missing capabilities, hallucinations, UX friction, feature requests, and docs gaps; pick the matching `category`. Region/project/source are inferred from the session. See [report-bugs.md](report-bugs.md) for the call shape.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/actions.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/actions.md
@@ -1,3 +1,8 @@
+---
+title: Agent Actions (Tools)
+description: Attach tools (actions) to agents, configure approval behaviour and ordering, and distinguish `action_id` from `studio_id`. Load when wiring tools to an agent or debugging why a tool doesn't appear at runtime.
+---
+
 # Agent Actions (Tools)
 
 How to attach and configure tools for agents.
@@ -43,50 +48,7 @@ Your project's API region may differ from where tools are stored.
 
 ### How to Find Tool Region (Recommended Pattern)
 
-```typescript
-// BEST: Find region from an existing working agent with tools
-const agents = await relevance_list_agents({ pageSize: 10 });
-const agentWithTools = agents.results.find((a) => a.actions?.length > 0);
-const correctRegion = agentWithTools.actions[0].region;
-
-// Use verified region when attaching tools
-const actions = toolIds.map((id) => ({
-  chain_id: id,
-  project: projectId,
-  region: correctRegion, // Use verified region
-  action_behaviour: 'never-ask',
-}));
-```
-
-Alternative methods:
-
-```typescript
-// Option 2: Get specific agent you know works
-const { agent } = await relevance_get_agent({ agentId: 'working-agent-id' });
-const region = agent.actions[0].region;
-
-// Option 3: Check tool metadata (less reliable)
-const tool = await relevance_get_tool({ studioId: 'tool-id' });
-// Look for tool.studio.metadata.source_marketplace_listing.entity_region
-```
-
-### Common Mistake
-
-```typescript
-// WRONG - using project/API region
-{
-  chain_id: "tool-id",
-  region: "bcbe5a",  // Your API region - MAY BE WRONG
-  project: "your-project-id"
-}
-
-// CORRECT - using tool's actual region
-{
-  chain_id: "tool-id",
-  region: "f1db6c",  // Region from working agent
-  project: "your-project-id"
-}
-```
+Run `relevance_list_agents` and look at the `region` field on any agent that already has the tool attached — that's the verified region. Pass that region into `relevance_attach_tools_to_agent` (or, for a single existing action, into `relevance_update_agent_action` with `patch: { region }`). As a fallback, `relevance_get_tool` returns the source region under `studio.metadata.source_marketplace_listing.entity_region`. Don't assume your project's API region is the same as the tool's region — they're commonly different.
 
 ### Symptoms of Wrong Region
 
@@ -99,7 +61,7 @@ const tool = await relevance_get_tool({ studioId: 'tool-id' });
 
 **Always verify tools are linked after publishing:**
 
-After publishing, call `relevance_get_agent_tools({ agentId })` to confirm tools are linked:
+After publishing, call `relevance_get_agent_tools({ agent_id })` to confirm tools are linked:
 
 - If `chains` is empty and `actionIdMap` is `{}` → region mismatch. Find the correct region from a working agent.
 - If `chains` has entries → tools are linked correctly. Use `actionIdMap` for system prompt references.
@@ -138,41 +100,23 @@ const action = {
 | `ask-first`  | Agent asks user before first use     | Sensitive operations |
 | `always-ask` | Requires explicit approval each time | Destructive actions  |
 
-## Adding Actions to an Agent
+## Adding and Configuring Actions
 
-```typescript
-// 1. Get current agent config
-const { agent } = await relevance_get_agent({ agentId: 'xxx' });
+Use `relevance_attach_tools_to_agent` to attach existing tools to an agent — it handles fetch/merge/save, sets `project`/`region` automatically, and saves to a draft.
 
-// 2. Add actions to config
-relevance_save_agent_draft({
-  agentId: 'xxx',
-  agentConfig: {
-    ...agent, // CRITICAL: preserve all existing fields
-    actions: [
-      {
-        chain_id: '653af72e-bee9-42ef-ad82-ca8c54715f85', // UUID from relevance_upsert_tool
-        project: config.project,
-        region: config.region,
-        title: 'Search Google',
-        description: 'Search the web for information',
-        action_behaviour: 'never-ask',
-      },
-      {
-        chain_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', // UUID from relevance_upsert_tool
-        project: config.project,
-        region: config.region,
-        title: 'Scrape Webpage',
-        description: 'Extract content from a URL',
-        action_behaviour: 'never-ask',
-      },
-    ],
-  },
-});
-
-// 3. Publish
-relevance_publish_agent({ agentId: 'xxx' });
 ```
+relevance_attach_tools_to_agent({
+  agent_id: 'xxx',
+  tool_ids: ['653af72e-bee9-42ef-ad82-ca8c54715f85'],
+  action_behaviour: 'never-ask',
+});
+```
+
+To change per-tool config on an already-attached tool — `prompt_description`, `default_values`, `overrides`, `conditional_approval_rules`, `agent_decide_prompt`, `disabled`, `action_retry_config`, `execution_limit`, or per-action `action_behaviour` — call `relevance_update_agent_action` with the tool's `chain_id` and a `patch` object.
+
+To remove one or more attached tools, call `relevance_detach_tools_from_agent` with the agent_id and an array of `chain_id`s. It throws if any chain_id isn't currently attached, so you don't silently believe a no-op succeeded.
+
+All three save to a draft; call `relevance_publish_agent` after the user confirms.
 
 ## CRITICAL: Action IDs vs Studio IDs
 
@@ -198,7 +142,7 @@ system_prompt: `Use {{_actions.3261d8205a334a99}} to create contacts.`;
 Backend-generated action IDs are required for system prompt references.
 
 ```typescript
-const tools = await relevance_get_agent_tools({ agentId: '...' });
+const tools = await relevance_get_agent_tools({ agent_id: '...' });
 // Returns:
 // {
 //   chains: [
@@ -215,6 +159,13 @@ const tools = await relevance_get_agent_tools({ agentId: '...' });
 See [actions.md - Action IDs vs Studio IDs](#critical-action-ids-vs-studio-ids) for the full reference.
 
 Use these IDs in system prompts: `{{_actions.3261d8205a334a99}}`
+
+## Integration Warnings
+
+After attaching tools with `relevance_attach_tools_to_agent`, check the response for:
+
+- **`oauth_auto_config`** — OAuth params are automatically set to "Set manually" mode. If exactly one matching OAuth account is connected, it's pre-filled as the default. Each entry includes a `config_url` linking directly to the tool's config page on the agent. If an account was NOT auto-filled (`account_set: false`), direct the user to the `config_url` to select their account.
+- **`integration_warnings`** — If tools need OAuth accounts or API keys that aren't configured, this field lists missing providers with a `setup_url` for the integrations page and per-tool `config_url` links. Use `relevance_check_tool_integration_requirements` for a detailed per-tool breakdown (pass `agent_id` to get config URLs), or follow the `setup-integrations` prompt for the full workflow.
 
 ## OAuth-Enabled Tools
 
@@ -244,55 +195,13 @@ LAYER 2: Agent actions[].default_values → Maps agent variable to tool input at
 LAYER 3: Tool params_schema → Fallback if agent doesn't pass value
 ```
 
-**All three layers are needed.**
+**All three layers are needed.** Apply each one with the right MCP tool:
 
-```typescript
-// 1. Get OAuth account ID
-const accounts = await relevance_list_oauth_accounts();
-const oauthAccountId = accounts.results.find(
-  (a) => a.provider === 'linkedin'
-).account_id;
-
-// 2. Update tool with default (Layer 3)
-await relevance_upsert_tool({
-  studio_id: 'my-linkedin-tool',
-  params_schema: {
-    properties: {
-      linkedin_account_id: {
-        type: 'string',
-        title: 'LinkedIn Account ID',
-        default: oauthAccountId, // LAYER 3: Tool fallback default
-      },
-    },
-  },
-});
-
-// 3. Configure agent with variable and action mapping (Layers 1 & 2)
-const { agent } = await relevance_get_agent({ agentId: 'my-agent' });
-await relevance_save_agent_draft({
-  agentId: agent.agent_id,
-  agentConfig: {
-    ...agent,
-    params_schema: {
-      type: 'object',
-      properties: {
-        linkedin_account_id: {
-          type: 'string',
-          title: 'LinkedIn Account ID',
-          default: oauthAccountId, // LAYER 1: Agent variable default
-        },
-      },
-    },
-    actions: agent.actions.map((action) => ({
-      ...action,
-      default_values: needsOAuth(action.chain_id)
-        ? { linkedin_account_id: '{{linkedin_account_id}}' } // LAYER 2: Maps variable to tool
-        : action.default_values,
-    })),
-  },
-});
-await relevance_publish_agent({ agentId: agent.agent_id });
-```
+1. Find the OAuth account id with `relevance_list_oauth_accounts`.
+2. **Layer 3 (tool fallback):** call `relevance_update_tool` with the tool's `studio_id` and a `params_schema` patch that sets `default: "<oauth_account_id>"` on the OAuth param.
+3. **Layer 1 (agent-level variable):** call `relevance_update_agent` with `patch: { params_schema: { type: "object", properties: { <oauth_param>: { type: "string", default: "<oauth_account_id>" } } } }`.
+4. **Layer 2 (per-action mapping):** for each affected attached tool, call `relevance_update_agent_action` with the tool's `chain_id` and `patch: { default_values: { <oauth_param>: "{{<oauth_param>}}" } }`. Do this once per attached tool.
+5. After the user confirms, call `relevance_publish_agent`.
 
 ## Listing Available OAuth Accounts
 

--- a/plugins/relevance-ai/skills/managing-relevance-agents/creating.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/creating.md
@@ -1,3 +1,8 @@
+---
+title: Creating Agents
+description: Create agents from scratch and configure core settings — model, system prompt, temperature, autonomy, memory, thinking, and phantom-tool flags. Load when building a new agent or changing its core config.
+---
+
 # Creating Agents
 
 Complete workflow for creating Relevance AI agents.
@@ -30,15 +35,15 @@ interface AgentConfig {
 
 ```typescript
 // WRONG — 422 error: unknown top-level field
-relevance_save_agent_draft({
-  agentId: '...',
-  agentConfig: { ...agent, max_output_tokens: 16000 },
+relevance_update_agent({
+  agent_id: '...',
+  patch: { max_output_tokens: 16000 },
 });
 
 // CORRECT — nested inside model_options
-relevance_save_agent_draft({
-  agentId: '...',
-  agentConfig: { ...agent, model_options: { max_output_tokens: 16000 } },
+relevance_update_agent({
+  agent_id: '...',
+  patch: { model_options: { max_output_tokens: 16000 } },
 });
 ```
 
@@ -113,7 +118,7 @@ Controls whether the agent asks for user approval before running tools.
 ### Step 1: Create Basic Agent
 
 ```typescript
-relevance_upsert_agent({
+relevance_create_agent({
   name: 'Research Assistant',
   description: 'Helps research topics using web search',
   system_prompt: `You are a helpful research assistant.
@@ -127,89 +132,76 @@ When the user asks about a topic:
 
 ### Step 2: Get Agent ID
 
+The `relevance_create_agent` response includes the new `agent_id` directly. If you've lost it, call `relevance_get_agent` (or list with `relevance_list_agents`) to retrieve it.
+
+### Step 3: Add Tools and Configure (saves as draft)
+
+Use `relevance_attach_tools_to_agent` to attach tools — it handles fetch/merge/save for you and saves to a draft:
+
 ```typescript
-const { agent } = await relevance_get_agent({ agentId: '...' });
+relevance_attach_tools_to_agent({
+  agent_id: agent.agent_id,
+  tool_ids: ['gtm-google-search'],
+  action_behaviour: 'never-ask',
+});
 ```
 
-### Step 3: Add Tools and Configure
+For other field changes (system_prompt, model, temperature, memory, etc.), use `relevance_update_agent` — partial-merge into the draft:
 
 ```typescript
-relevance_save_agent_draft({
-  agentId: agent.agent_id,
-  agentConfig: {
-    ...agent, // CRITICAL: Include all existing fields
-    actions: [
-      {
-        chain_id: 'gtm-google-search',
-        project: config.project, // REQUIRED
-        region: config.region, // REQUIRED
-        title: 'Search Google',
-        description: 'Search the web for information',
-        action_behaviour: 'never-ask',
-      },
-    ],
+relevance_update_agent({
+  agent_id: agent.agent_id,
+  patch: {
+    temperature: 0.3,
+    memory: { enabled: true, memory_level: 'user' },
   },
 });
 ```
 
-### Step 4: Publish
-
-```typescript
-relevance_publish_agent({ agentId: agent.agent_id });
-```
-
-### Step 5: Verify OAuth Integrations
+### Step 4: Verify OAuth Integrations
 
 If any attached tools require OAuth (check `params_schema` for `metadata.content_type === "oauth_account"`), verify the connection:
 
 1. Call `relevance_list_oauth_accounts` to check connected accounts
 2. If a required provider is missing, call `relevance_get_project_info` to get the integrations page URL and direct the user to connect it
 
-### Step 6: Test
+### Step 5: Test the Draft
 
 ```typescript
 relevance_trigger_agent({
-  agentId: agent.agent_id,
+  agent_id: agent.agent_id,
   message: 'Research the latest AI developments',
 });
+// Response includes triggered_version: "draft" so you know which version ran.
+```
+
+### Step 6: Ask the User, Then Publish
+
+After the user has reviewed the draft and confirmed they want it live, publish it.
+`relevance_publish_agent` always shows an approval card (even with auto-approve enabled).
+
+```typescript
+relevance_publish_agent({ agent_id: agent.agent_id });
 ```
 
 ## Best Practice: Examine Working Agents First
 
-Before creating a new agent, check how similar working agents are configured:
-
-```typescript
-// 1. List existing agents
-const agents = await relevance_list_agents({ pageSize: 10 });
-
-// 2. Find one with similar tools
-const { agent } = await relevance_get_agent({ agentId: 'working-agent-id' });
-
-// 3. Inspect the region used in actions
-// This is CRITICAL - use the same region for the same tools
-// Check agent.actions for chain_id and region values
-```
-
-This reveals:
-
-- Correct `region` values for tools (often different from your project region!)
-- Working `action_behaviour` patterns
-- System prompt patterns that reference tools
+Before creating a new agent, look at how similar working agents are configured. Run `relevance_list_agents`, then `relevance_get_agent` on one that already uses the tools you want — read the `region` field on each entry of its `actions` array. This is CRITICAL: tools must be attached with the **region the tool lives in**, which is often different from your project's region. The same fetch also surfaces working `action_behaviour` patterns and system-prompt structure to copy.
 
 ## Agent Lifecycle
 
 ```text
-1. Create basic agent (relevance_upsert_agent)
+1. Create basic agent (relevance_create_agent — saves to DRAFT only)
         |
 2. Get agent to see ID (relevance_get_agent)
         |
-3. Add tools/config (relevance_save_agent_draft)
+3. Add tools / configure (relevance_attach_tools_to_agent / relevance_update_agent — saves draft)
         |
-4. Publish (relevance_publish_agent)
+4. Verify OAuth (relevance_list_oauth_accounts + relevance_get_project_info)
         |
-5. Verify OAuth (relevance_list_oauth_accounts + relevance_get_project_info)
+5. Test the draft (relevance_trigger_agent — defaults to draft)
         |
-6. Test (relevance_trigger_agent)
+6. Ask the user → Publish (relevance_publish_agent — always confirms with the user)
         |
 7. Add triggers if needed (relevance_create_trigger)
 ```
@@ -225,57 +217,9 @@ This reveals:
 
 ## Common Patterns
 
-### Search and Summarize Agent
-
-```typescript
-{
-  name: "Research Assistant",
-  system_prompt: `You help research topics.
-
-When asked about something:
-1. Search for information using Google Search
-2. Read relevant pages with the scraper
-3. Synthesize and summarize findings`,
-  actions: [
-    { chain_id: "google-search", action_behaviour: "never-ask", project: "...", region: "..." },
-    { chain_id: "web-scraper", action_behaviour: "never-ask", project: "...", region: "..." }
-  ]
-}
-```
-
-### Data Enrichment Agent
-
-```typescript
-{
-  name: "Lead Enricher",
-  system_prompt: `You enrich lead data.
-
-Given a company or person:
-1. Search for their website
-2. Extract key information
-3. Find contact details`,
-  actions: [
-    { chain_id: "google-search", project: "...", region: "..." },
-    { chain_id: "contact-finder", project: "...", region: "..." },
-    { chain_id: "linkedin-scraper", project: "...", region: "..." }
-  ]
-}
-```
-
-### Event-Driven Agent
-
-```typescript
-{
-  name: "Meeting Prep Assistant",
-  system_prompt: `You prepare meeting briefings.
-
-When triggered by a calendar event:
-1. Extract attendee information
-2. Research their company
-3. Prepare talking points`
-  // Triggered via google_calendar trigger
-}
-```
+- **Search and Summarize:** attach a search tool and a scraper. System prompt: search → read pages → synthesize.
+- **Data Enrichment:** attach search + contact-finder + a profile scraper (e.g. LinkedIn). System prompt: search for the entity → extract details → find contact info.
+- **Event-Driven:** attach the relevant data-fetching tools, leave triggers to `relevance_create_trigger`. System prompt explains how to react when the trigger fires.
 
 ## Testing
 

--- a/plugins/relevance-ai/skills/managing-relevance-agents/memory.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/memory.md
@@ -1,3 +1,8 @@
+---
+title: Agent Memory
+description: Configure persistent agent memory — enabling, project vs user scope, categories, and the add/delete memory tools. Load when enabling memory, setting scope, or troubleshooting why facts aren't being retained.
+---
+
 # Agent Memory
 
 A guide to understanding and using the Agent Memory feature in Relevance AI.
@@ -45,26 +50,7 @@ interface AgentMemory {
 
 ### Example Configuration
 
-```typescript
-// Get agent, add memory config, save and publish
-const { agent } = await relevance_get_agent({ agentId: 'my-agent' });
-
-await relevance_save_agent_draft({
-  agentId: agent.agent_id,
-  agentConfig: {
-    ...agent,
-    memory: {
-      enabled: true,
-      memory_level: 'user',
-      enable_delete_tool: true,
-      add_memory_prompt:
-        'Save important user preferences and facts that will help personalize future interactions.',
-    },
-  },
-});
-
-await relevance_publish_agent({ agentId: agent.agent_id });
-```
+Call `relevance_update_agent` with a `patch.memory` object that sets the fields above (saves to draft), then call `relevance_publish_agent` after the user confirms.
 
 ## Memory Levels
 
@@ -201,15 +187,7 @@ Delete memories when:
 
 ### Customizing Prompts
 
-```typescript
-{
-  memory: {
-    enabled: true,
-    add_memory_prompt: "Only save information that the user explicitly asks you to remember. Focus on professional context and project requirements.",
-    delete_memory_prompt: "Delete memories when the user says 'forget' or when information becomes outdated."
-  }
-}
-```
+To override the defaults, call `relevance_update_agent` with `patch: { memory: { enabled: true, add_memory_prompt: "...", delete_memory_prompt: "..." } }`. Either prompt can be customized independently; omitted fields keep the platform defaults.
 
 ## How Memory Recall Works
 

--- a/plugins/relevance-ai/skills/managing-relevance-agents/phantom-tools.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/phantom-tools.md
@@ -1,3 +1,8 @@
+---
+title: Phantom Tools
+description: Reference for the 15 system-injected tools (thinking, memory, escalation, Python executor, remote MCP, etc.) that are enabled via agent settings and must never be written into the `actions` array. Load when these tools appear in errors or when enabling agent capabilities.
+---
+
 # Phantom Tools
 
 Phantom tools are **system-injected tools generated at runtime** from agent settings. They are never stored in the agent's `actions` array — the Relevance AI backend creates them dynamically when the agent runs, based on configuration flags.
@@ -33,7 +38,7 @@ enable_python_executor: true         →   python_executor
 remote_mcp_configs: [...]            →   mcp_remote_tool_call
 ```
 
-When `relevance_get_agent_tools` returns tools, phantom tools are included with `is_phantom_tool: true`. But they should **never** be written back via `relevance_save_agent_draft`.
+When `relevance_get_agent_tools` returns tools, phantom tools are included with `is_phantom_tool: true`. But they should **never** be written back to the agent's `actions` array via `relevance_update_agent` or `relevance_attach_tools_to_agent`.
 
 ## Complete Reference: All 15 Phantom Tools
 
@@ -46,18 +51,7 @@ When `relevance_get_agent_tools` returns tools, phantom tools are included with 
 | **Purpose**       | Internal scratchpad — agent uses this to reason through complex decisions before acting |
 | **How to enable** | Set `thinking_tool: { enabled: true }` on the agent config                              |
 
-```typescript
-// Enable thinking tool
-const { agent } = await relevance_get_agent({ agentId });
-await relevance_save_agent_draft({
-  agentId,
-  agentConfig: {
-    ...agent,
-    thinking_tool: { enabled: true },
-  },
-});
-await relevance_publish_agent({ agentId });
-```
+Enable via `relevance_update_agent` with `patch: { thinking_tool: { enabled: true } }`, then publish.
 
 ### Agent Memory Tools
 
@@ -70,23 +64,7 @@ await relevance_publish_agent({ agentId });
 
 The `delete_agent_memory` tool is only injected when `memory.enable_delete_tool: true`.
 
-```typescript
-// Enable memory tools
-await relevance_save_agent_draft({
-  agentId,
-  agentConfig: {
-    ...agent,
-    memory: {
-      enabled: true,
-      memory_level: 'user', // "project" (shared) or "user" (per-user)
-      enable_delete_tool: true, // Also inject delete tool
-      add_memory_prompt: 'Save important facts and user preferences.',
-    },
-  },
-});
-```
-
-See [memory.md](memory.md) for full memory documentation.
+Enable via `relevance_update_agent` with `patch: { memory: { enabled: true, memory_level: "user" | "project", enable_delete_tool: true, add_memory_prompt: "..." } }`. See [memory.md](memory.md) for full memory documentation.
 
 ### Conversation Tagging Tool
 
@@ -97,16 +75,7 @@ See [memory.md](memory.md) for full memory documentation.
 | **Purpose**       | Tag conversations with predefined labels for organization/routing |
 | **How to enable** | Set `tags: ["support", "billing", "sales"]` on the agent config   |
 
-```typescript
-// Enable conversation tagging
-await relevance_save_agent_draft({
-  agentId,
-  agentConfig: {
-    ...agent,
-    tags: ['support', 'billing', 'technical', 'sales'],
-  },
-});
-```
+`tags` is blocked from MCP modification — set it via the Relevance AI dashboard. See the **Blocked Fields** section below for why.
 
 ### Conversation Metadata Tools
 
@@ -126,16 +95,7 @@ await relevance_save_agent_draft({
 | **Purpose**       | Allow the agent to schedule future actions (reminders, follow-ups) |
 | **How to enable** | Set `is_scheduled_triggers_enabled: true`                          |
 
-```typescript
-// Enable scheduled triggers
-await relevance_save_agent_draft({
-  agentId,
-  agentConfig: {
-    ...agent,
-    is_scheduled_triggers_enabled: true,
-  },
-});
-```
+Enable via `relevance_update_agent` with `patch: { is_scheduled_triggers_enabled: true }`.
 
 ### Escalate to Manager Tool
 
@@ -146,23 +106,7 @@ await relevance_save_agent_draft({
 | **Purpose**       | Escalate conversations to human managers via email or Slack notifications                        |
 | **How to enable** | Set `escalations: { email: { emails: [...] } }` or `escalations: { slack: { channels: [...] } }` |
 
-```typescript
-// Enable escalation
-await relevance_save_agent_draft({
-  agentId,
-  agentConfig: {
-    ...agent,
-    escalations: {
-      email: {
-        emails: ['manager@company.com'],
-      },
-      slack: {
-        channels: ['#escalations'],
-      },
-    },
-  },
-});
-```
+`escalations` is blocked from MCP modification — set it via the Relevance AI dashboard. See the **Blocked Fields** section below for why.
 
 ### Python Executor Tool
 
@@ -220,26 +164,15 @@ When processing agent tool data, use these methods (in order of reliability):
 
 ### Phantom Tools Are Auto-Stripped on Save
 
-The `relevance_save_agent_draft` tool automatically strips phantom tools before saving. When updating an agent, always use `agent.actions` from `relevance_get_agent` (already clean) — never use `tools.chains` from `relevance_get_agent_tools` (includes phantom tools).
+The MCP layer automatically strips phantom tools before saving (whether you go through `relevance_update_agent` or `relevance_attach_tools_to_agent`). When constructing an `actions` array yourself, always source it from `relevance_get_agent` (already clean) — never from `relevance_get_agent_tools` (includes phantom tools).
 
 ### Enable Features via Settings, Not Actions
 
-To give an agent capabilities like memory or thinking, configure the **setting** — don't manually add the tool to `actions`.
-
-```typescript
-// BAD — manually adding phantom tool to actions
-actions: [
-  ...agent.actions,
-  { chain_id: "thinking_tool", title: "Think" }  // Will corrupt agent
-]
-
-// GOOD — enable via setting
-{ ...agent, thinking_tool: { enabled: true } }
-```
+To give an agent capabilities like memory or thinking, set the feature flag with `relevance_update_agent` (e.g. `patch: { thinking_tool: { enabled: true } }`). The MCP injects the phantom tool automatically. Don't add phantom tools to the `actions` array — it corrupts the agent and `relevance_update_agent` will reject the array anyway because the array-replacement semantics would also wipe other attached tools.
 
 ### Cloned Agents May Be Pre-Tainted
 
-If an agent was published to the marketplace with phantom tools already leaked into its `actions` (from a previous bug), cloning it reproduces the tainted data. Re-saving the agent via `relevance_save_agent_draft` will automatically clean this up.
+If an agent was published to the marketplace with phantom tools already leaked into its `actions` (from a previous bug), cloning it reproduces the tainted data. Re-saving the agent via `relevance_update_agent` (passing any small change to trigger a save) will automatically clean this up.
 
 ### `params_schema` Is Valid — Don't Strip It
 
@@ -247,7 +180,7 @@ A common mistake when cleaning actions is deleting `params_schema`. This field I
 
 ### Blocked Fields in MCP Plugin
 
-The following agent config fields are **blocked from modification** via `relevance_patch_agent` and `relevance_upsert_agent` because they control phantom tool injection and can cause hard-to-reverse damage if set incorrectly:
+The following agent config fields are **blocked from modification** via `relevance_update_agent` and `relevance_create_agent` because they control phantom tool injection and can cause hard-to-reverse damage if set incorrectly:
 
 - `tags` — controls `tag_agent_conversation` phantom tool. **Not** a general-purpose metadata/labelling field.
 - `custom_metadata` — controls `add_conversation_metadata` / `read_conversation_metadata` phantom tools.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/phone-agents.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/phone-agents.md
@@ -1,3 +1,8 @@
+---
+title: Phone Agent Best Practices
+description: Build production phone agents using the three-phase pre-call / phone / post-call pattern, with voice config, latency guidance, and prompt structure. Load when designing a voice agent or optimising call latency.
+---
+
 # Phone Agent Best Practices
 
 Reference for building production-grade phone agents on Relevance AI.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/report-bugs.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/report-bugs.md
@@ -1,158 +1,86 @@
 ---
-description: Instructs agents to report bugs, skill gaps, and UX friction via the SubmitBugReport API. Use when encountering issues during agent conversations.
+description: How agents file bugs and improvement suggestions through MCP. Submit proactively whenever a tool errors, a capability is missing, or the user asks for something the platform doesn't support.
 ---
 
-# Bug Reporting
+# Reporting Bugs and Suggesting Improvements
 
-When a significant issue is encountered during a conversation, the agent should analyze what went wrong and submit a structured report via the bug report API.
+Use the `relevance_submit_feedback` MCP tool. One tool covers both bugs and forward-looking suggestions — the `category` field tells engineering which it is. Region/project/source are inferred from the session. **Submit proactively** — do NOT ask the user for permission first.
 
-## Reporting Limits
+## When to call
 
-- **Maximum 2 reports per conversation.** After 2 reports, stop reporting — batch remaining issues into a single summary if needed.
-- **Never report failures of the reporting endpoint itself.** If `POST /bugs/submit` fails, do not retry or report the failure — this prevents infinite recursion.
-- **Deduplicate within a conversation.** Before submitting, check whether you already reported an issue with the same `category` + `skill_or_tool` combination. If so, skip it.
+| Category          | When                                                                     |
+| ----------------- | ------------------------------------------------------------------------ |
+| `bug`             | A tool call failed, returned wrong data, or threw an error               |
+| `skill-gap`       | The agent lacked a tool/capability and the user gave up or worked around |
+| `ux-friction`     | The user had to repeat themselves or correct the agent                   |
+| `hallucination`   | The agent fabricated a tool name, parameter, or capability               |
+| `feature-request` | The user asked for something the platform doesn't support yet            |
+| `improvement`     | An existing capability could be better; you worked around a limitation   |
+| `docs`            | A skill doc was missing the answer you needed                            |
 
-## When to Report
+**Don't report:** successful conversations, user errors unrelated to the platform (typos in their data), or the same `category` + `title` twice in one conversation. Don't report failures of the feedback tool itself (prevents recursion).
 
-Report when ANY of the following occur during a conversation:
-
-- **Bug**: A tool call failed, returned unexpected data, or the agent hit an error
-- **Skill gap**: The agent lacked knowledge or a tool to fulfill the user's request
-- **UX friction**: The user had to repeat themselves, correct the agent, or abandon a task
-- **Feature request**: The user explicitly asked for something the platform doesn't support
-- **Hallucination**: The agent fabricated capabilities, tool names, or configuration options
-
-Do NOT report:
-
-- Successful conversations with no issues
-- User errors unrelated to the platform (e.g. typos in their own data)
-- Issues already reported in the same conversation
-- Failures of the `POST /bugs/submit` endpoint itself
-
-## How to Report
-
-Use the `relevance_api_request` MCP tool to call the `POST /bugs/submit` endpoint.
+## Calling the tool
 
 ```typescript
-relevance_api_request({
-  method: 'POST',
-  endpoint: '/bugs/submit',
-  body: {
-    source: 'mcp-auto',
-    region: '<current region>',
-    project: '<current project ID>',
-    message: 'Detailed description of the issue',
-    category: 'bug | skill-gap | ux-friction | feature-request | hallucination',
-    context: {
-      severity: 'low | medium | high | critical',
-      title: 'Short summary (under 100 chars)',
-      suggested_fix: 'Concrete suggestion for how to fix',
-      agent_id: 'agent ID if available',
-      conversation_id: 'conversation/task ID if available',
-      skill_or_tool: 'MCP tool or skill involved',
-    },
-  },
+relevance_submit_feedback({
+  category: 'bug', // see table above
+  severity: 'high', // critical | high | medium | low
+  title:
+    'relevance_update_agent dropped all attached tools on a partial update',
+  message:
+    'User asked to change only the system_prompt of agent 5f8e0e41. ' +
+    'Called relevance_update_agent with just { agent_id, system_prompt }. ' +
+    'The attached tools were wiped (actions dropped from 2 to 0) even though I only sent system_prompt — the partial-merge did not preserve actions.',
+  agent_id: '5f8e0e41-98bf-4068-90ed-2a722fb68466',
+  skill_or_tool: 'relevance_update_agent',
 });
 ```
 
-> **Note:** `region` and `project` are required by the API. Use the region and project ID from the current MCP session context (e.g. `relevance_get_project_info`).
+### Field reference
 
-### Field Reference
+| Field             | Required | Notes                                                                |
+| ----------------- | -------- | -------------------------------------------------------------------- |
+| `category`        | Yes      | One of the seven categories above                                    |
+| `severity`        | Yes      | `critical` blocks, `high`/`medium` is friction, `low` is minor       |
+| `title`           | Yes      | Short ticket-style title (5–120 chars)                               |
+| `message`         | Yes      | What happened, in plain prose. ≥20 chars. Don't prescribe a fix.     |
+| `agent_id`        | No       | Agent ID if issue is agent-specific                                  |
+| `conversation_id` | No       | Conversation/task ID if already in your context — never ask the user |
+| `skill_or_tool`   | No       | The MCP tool or skill involved                                       |
 
-| Field                     | Required | Notes                                                                                                  |
-| ------------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `source`                  | Yes      | Always `"mcp-auto"` for agent-generated reports                                                        |
-| `region`                  | Yes      | Current region code (e.g. `"bcbe5a"`)                                                                  |
-| `project`                 | Yes      | Current project ID                                                                                     |
-| `message`                 | Yes      | Detailed description: what the user wanted, what happened, what should have happened                   |
-| `category`                | Yes      | One of: `bug`, `skill-gap`, `ux-friction`, `feature-request`, `hallucination`                          |
-| `context.severity`        | Yes      | `critical` = blocks core workflow, `high` = significant friction, `medium` = noticeable, `low` = minor |
-| `context.title`           | Yes      | Short, actionable — like a ticket title                                                                |
-| `context.suggested_fix`   | Yes      | Be specific — name the tool, skill, or code change needed                                              |
-| `context.agent_id`        | No       | Include when the issue is agent-specific                                                               |
-| `context.conversation_id` | No       | The task_id or conversation_id                                                                         |
-| `context.skill_or_tool`   | No       | The specific MCP tool or skill that was involved                                                       |
+## Writing a good `message`
 
-### Sanitization Rules
+Keep it short. A few sentences is usually enough. Cover, in plain prose:
 
-Reports are stored persistently. **MUST NOT include:**
+- What the user wanted
+- What you tried (the specific tool / parameters)
+- What went wrong, or what's missing
 
-- API keys, tokens, passwords, or OAuth secrets
-- Auth headers, session cookies, or bearer tokens
-- Raw PII (emails, phone numbers, addresses) — use `[REDACTED]` placeholders
-- Full stack traces — include only the error class/code and message
-- Raw request/response bodies — summarize the shape and relevant fields only
+**Do not** prescribe how engineering should fix it — that's their call. Describing the _symptom_ well is more useful than guessing the _fix_.
+
+If a workaround exists, mention it in one line.
+
+## Sanitization
+
+Reports are stored persistently. **Never include:**
+
+- API keys, tokens, passwords, OAuth secrets, Authorization headers
+- Raw PII (emails, phone numbers, addresses) — use `[REDACTED]`
+- Full stack traces — error class + message is enough
+- Raw request/response bodies — summarize the shape
+
+The tool will reject the call with a sanitization error if obvious secret patterns are detected.
 
 ```typescript
 // WRONG — leaks secrets
 message: 'Tool failed with header Authorization: Bearer sk-abc123...';
 
 // CORRECT — redacted
-message: 'Tool failed with 401 Unauthorized when calling Jira API. Auth header was present but rejected.';
+message: 'Tool failed with 401 Unauthorized when calling Jira API.';
 ```
 
-### Writing a Good `message`
-
-The `message` field is the most important part of the report. Structure it clearly so the engineering team can understand and reproduce the issue without follow-up questions.
-
-**Use this format:**
-
-```
-## Summary
-One-sentence description of what went wrong.
-
-## Steps to Reproduce
-1. What the user asked for
-2. What tool/action was attempted
-3. What parameters were used (redact secrets)
-
-## Expected Behavior
-What should have happened.
-
-## Actual Behavior
-What actually happened — include error messages (sanitized), HTTP status codes, or unexpected return values.
-
-## Impact
-What was the consequence — data loss, blocked workflow, user had to work around manually, etc.
-
-## Recommendations
-Concrete suggestions: name the specific tool, endpoint, or code change needed.
-```
-
-**Tips for actionable reports:**
-
-- Lead with the user's intent, not just the error
-- Include the exact MCP tool name and parameters that triggered the issue
-- Note whether a workaround exists and what it is
-- If data was lost or corrupted, describe what changed (before vs after)
-- Be specific in recommendations — "add a list_templates tool" is better than "fix this"
-
-### Example
-
-```typescript
-relevance_api_request({
-  method: 'POST',
-  endpoint: '/bugs/submit',
-  body: {
-    source: 'mcp-auto',
-    region: 'bcbe5a',
-    project: 'a3cd1b1efb8c-4da4-8728-81a8bc7333ca',
-    message:
-      '## Summary\nrelevance_api_request with POST /agents/upsert wiped entire agent config when attempting a partial update.\n\n## Steps to Reproduce\n1. User asked to update only the system_prompt of agent 5f8e0e41\n2. Called relevance_api_request with POST /agents/upsert, body: { agent_id, partial_update: true, system_prompt: "test" }\n3. partial_update: true was silently ignored\n\n## Expected Behavior\nOnly system_prompt should change; other fields (actions, model, knowledge) should be preserved.\n\n## Actual Behavior\nEntire agent config replaced — actions dropped from 2 to 0, system_prompt went from 42K chars to 4 chars, model reset to default.\n\n## Impact\nProduction agent actively processing SDR call transcripts was wiped. Recovered via version rollback.\n\n## Recommendations\n1. Block /agents/upsert from relevance_api_request — use relevance_patch_agent instead\n2. Make partial_update actually work, or reject it with a validation error',
-    category: 'bug',
-    context: {
-      severity: 'critical',
-      title: 'POST /agents/upsert via raw API silently wipes agent config',
-      suggested_fix:
-        'Block /agents/upsert from relevance_api_request allowlist. Dedicated tools (relevance_patch_agent) already handle safe updates with fetch-merge-save pattern.',
-      agent_id: '5f8e0e41-98bf-4068-90ed-2a722fb68466',
-      skill_or_tool: 'relevance_api_request',
-    },
-  },
-});
-```
-
-## Severity Guide
+## Severity guide
 
 | Severity   | Criteria                                                       | Example                                                   |
 | ---------- | -------------------------------------------------------------- | --------------------------------------------------------- |
@@ -161,12 +89,6 @@ relevance_api_request({
 | `medium`   | Noticeable issue but workaround exists                         | Search returns wrong results but user can filter manually |
 | `low`      | Minor inconvenience or cosmetic issue                          | Tool description is confusing but functionality works     |
 
-## Triage Process
+## Triage
 
-Reports submitted via `POST /bugs/submit` are stored server-side and triaged by the engineering team:
-
-1. Filter reports where `source = 'mcp-auto'`
-2. Assess severity and category
-3. Convert actionable reports into Linear tickets
-4. Group related reports to identify patterns
-5. Prioritize based on frequency and severity
+Reports are stored server-side and triaged by engineering — filter on `source = 'mcp-auto'`, group by `category` and frequency, convert actionable ones into Linear tickets. Per-project rate limiting on the feedback tool keeps the volume sane.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/running.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/running.md
@@ -1,3 +1,8 @@
+---
+title: Running and Testing Agents
+description: Trigger agents, poll for results, inspect conversations and tool calls. Load when running or testing an agent, or debugging tool-execution failures inside a conversation.
+---
+
 # Running and Testing Agents
 
 How to trigger agents, manage conversations, and view results.
@@ -8,45 +13,68 @@ How to trigger agents, manage conversations, and view results.
 
 Use `relevance_trigger_agent` to send a message. Returns immediately with a `conversation_id`:
 
+> **Note:** `conversation_id` (returned by trigger/poll tools) and `task_id` (used by view/metadata tools) are the same value. Use the `conversation_id` from a trigger result as the `task_id` when calling `relevance_get_agent_task_summary`, `relevance_list_agent_task_messages`, or `relevance_get_agent_task_metadata`.
+
 ```typescript
 const result = await relevance_trigger_agent({
-  agentId: '...',
+  agent_id: '...',
   message: 'Research the latest AI developments',
 });
-// Returns { conversation_id } immediately
+// Returns { conversation_id } immediately — this is the task_id for other agent task tools
 // Use relevance_poll_agent_result to check status and get the response
 ```
 
-### Synchronous (Wait for Completion)
+### Polling Pacing
 
-Use `relevance_trigger_agent_sync` to trigger and wait for completion (up to 120s):
+When polling for results with `relevance_poll_agent_result`, **always pass `wait_seconds`** (default 50s, max 300s). The platform-API holds the connection open until the agent reaches a terminal status (`completed`, `failed`, `pending_approval`) or the wait window elapses, so one call covers many internal polls.
 
 ```typescript
-const result = await relevance_trigger_agent_sync({
-  agentId: '...',
+relevance_poll_agent_result({
+  agent_id: '...',
+  conversation_id: '...',
+  wait_seconds: 50,
+});
+```
+
+If a poll returns a non-terminal `status: "in_progress"`, **re-poll** — do NOT call `relevance_trigger_agent` again. Re-triggering starts a new conversation; the existing one is still running.
+
+A `polling_hint` field on the response only appears for `pending_approval` and includes the conversation URL the human approver must visit.
+
+### Wait for Completion
+
+There is no synchronous trigger. To wait for the agent's response, call `relevance_poll_agent_result` with `wait_seconds` after triggering — the platform-API holds the connection open until a terminal status (`completed`, `failed`, `pending_approval`) or the wait window elapses.
+
+```typescript
+const { conversation_id } = await relevance_trigger_agent({
+  agent_id: '...',
   message: 'Research the latest AI developments',
 });
-// Returns { status, response, toolCalls } when done
+const task = await relevance_poll_agent_result({
+  agent_id: '...',
+  conversation_id,
+  wait_seconds: 50,
+});
+// Re-poll while task.status === "in_progress"
 ```
 
 ### Continue Existing Conversation
 
 ```typescript
 relevance_trigger_agent({
-  agentId: '...',
-  conversationId: 'previous-conversation-id',
+  agent_id: '...',
+  conversation_id: 'previous-conversation-id',
   message: 'Tell me more about transformers',
 });
 ```
 
-## Viewing Conversations
+## Viewing Agent Tasks
 
-### Get Conversation Details
+### Get Task Summary
 
 ```typescript
-relevance_get_task_view({
-  agentId: '...',
-  taskId: 'conversation-id',
+relevance_get_agent_task_summary({
+  agent_id: '...',
+  task_id: 'conversation-id', // Use the conversation_id as task_id
 });
 ```
 
@@ -60,16 +88,6 @@ Returns summarized view with:
 
 ### Full Mode
 
-For complete raw API response:
-
-```typescript
-relevance_get_task_view({
-  agentId: '...',
-  taskId: 'conversation-id',
-  fullMode: true,
-});
-```
-
 ## Testing Workflow
 
 ### 0. Validate Tools First
@@ -78,7 +96,7 @@ Before testing the agent, validate each attached tool individually to catch brok
 
 ```typescript
 const result = await relevance_run_tool({
-  studioId: 'tool-id',
+  studio_id: 'tool-id',
   params: { query: 'test input' },
 });
 // ✅ Returns meaningful data → tool works
@@ -92,7 +110,7 @@ This prevents wasting agent credits on tools that silently return empty results.
 ```typescript
 // Simple message to verify agent responds
 relevance_trigger_agent({
-  agentId: '...',
+  agent_id: '...',
   message: 'Hello, what can you help me with?',
 });
 ```
@@ -102,7 +120,7 @@ relevance_trigger_agent({
 ```typescript
 // Message that requires tool use
 relevance_trigger_agent({
-  agentId: 'research-assistant',
+  agent_id: 'research-assistant',
   message: 'Search for recent news about OpenAI',
 });
 ```
@@ -112,14 +130,14 @@ relevance_trigger_agent({
 ```typescript
 // Start conversation
 const result1 = await relevance_trigger_agent({
-  agentId: '...',
+  agent_id: '...',
   message: "Research Tesla's latest quarterly earnings",
 });
 
 // Continue with follow-up
 relevance_trigger_agent({
-  agentId: '...',
-  conversationId: result1.conversation_id,
+  agent_id: '...',
+  conversation_id: result1.conversation_id,
   message: 'How does this compare to last quarter?',
 });
 ```
@@ -129,9 +147,9 @@ relevance_trigger_agent({
 ### Check Conversation for Errors
 
 ```typescript
-const task = await relevance_get_task_view({
-  agentId: '...',
-  taskId: 'conversation-id',
+const task = await relevance_get_agent_task_summary({
+  agent_id: '...',
+  task_id: 'conversation-id', // conversation_id is the task_id
 });
 
 // Look for:
@@ -142,14 +160,14 @@ const task = await relevance_get_task_view({
 
 ### Common Issues
 
-| Symptom                   | Likely Cause                     | Fix                                                         |
-| ------------------------- | -------------------------------- | ----------------------------------------------------------- |
-| Agent doesn't use tools   | System prompt unclear            | Make tool instructions explicit                             |
-| Tool execution fails      | Missing project/region           | Add to action config                                        |
-| Wrong tool called         | Tool descriptions unclear        | Update action descriptions                                  |
-| Slow response             | Too many tools                   | Remove unused tools                                         |
-| `pending_approval` status | `action_behaviour: "always-ask"` | Approve in UI, or change to `"never-ask"` for automated use |
-| `timed_out` status        | Agent takes >120s                | Use `relevance_get_task_view` to poll — do NOT re-trigger   |
+| Symptom                       | Likely Cause                     | Fix                                                            |
+| ----------------------------- | -------------------------------- | -------------------------------------------------------------- |
+| Agent doesn't use tools       | System prompt unclear            | Make tool instructions explicit                                |
+| Tool execution fails          | Missing project/region           | Add to action config                                           |
+| Wrong tool called             | Tool descriptions unclear        | Update action descriptions                                     |
+| Slow response                 | Too many tools                   | Remove unused tools                                            |
+| `pending_approval` status     | `action_behaviour: "always-ask"` | Approve in UI, or change to `"never-ask"` for automated use    |
+| `in_progress` after long wait | Agent still running              | Re-poll with `relevance_poll_agent_result` — do NOT re-trigger |
 
 ## URL Patterns
 
@@ -170,9 +188,33 @@ https://app.relevanceai.com/agents/{region}/{project}/{agentId}/edit/instruction
 
 ## API Direct Access
 
-### List Conversations
+### List Tasks (Conversations)
 
-Use `relevance_list_conversations` to list agent conversations.
+Use `relevance_list_agent_tasks` to list agent tasks (conversations).
+
+### List Task Messages
+
+Use `relevance_list_agent_task_messages` to get raw messages from an agent task:
+
+```typescript
+const messages = await relevance_list_agent_task_messages({
+  agent_id: '...',
+  task_id: 'task-id',
+});
+// Returns raw message list from the task
+```
+
+### Get Task Metadata
+
+Use `relevance_get_agent_task_metadata` to get task metadata (status, credits used, runtime):
+
+```typescript
+const metadata = await relevance_get_agent_task_metadata({
+  agent_id: '...',
+  task_id: 'task-id',
+});
+// Returns status, credits consumed, runtime duration, etc.
+```
 
 ### List Jobs in Conversation
 
@@ -184,44 +226,15 @@ relevance_api_request({
 });
 ```
 
-## Task View Pagination
-
-`relevance_get_task_view` supports cursor-based pagination for handling large conversations:
-
-```typescript
-// First request
-const page1 = await relevance_get_task_view({
-  agentId: 'my-agent',
-  taskId: 'conversation-id',
-  pageSize: 100,
-});
-// Response includes next_cursor if more messages exist
-
-// Get older messages using cursor
-if (page1.next_cursor) {
-  const page2 = await relevance_get_task_view({
-    agentId: 'my-agent',
-    taskId: 'conversation-id',
-    pageSize: 100,
-    cursor: { before: page1.next_cursor }, // Get messages BEFORE this timestamp
-  });
-}
-```
-
-**Cursor options:**
-
-- `cursor.before` - Get messages before this ISO timestamp (for going back in time)
-- `cursor.after` - Get messages after this ISO timestamp (for new messages)
-
 ## Dry Run / Safe Testing Pattern
 
-For agents with potentially destructive tools (e.g. sending emails, deleting data), set `action_behaviour: "always-ask"` on those tools using `relevance_patch_agent` during testing.
+For agents with potentially destructive tools (e.g. sending emails, deleting data), set `action_behaviour: "always-ask"` on those tools using `relevance_update_agent` during testing.
 
 When triggered, the agent will pause at `pending_approval` status before executing the tool. You can:
 
 1. Review the tool call parameters in the Relevance AI app (use `relevance_get_project_info` for the URL)
 2. Approve or reject the call
-3. Use `relevance_get_task_view` to see the result after approval
+3. Use `relevance_get_agent_task_summary` to see the result after approval
 
 Once verified, switch back to `"never-ask"` for production use.
 
@@ -232,5 +245,5 @@ Once verified, switch back to `"never-ask"` for production use.
 3. **Verify tool outputs** - Ensure tools return expected data
 4. **Test with diverse inputs** - Don't rely on a single test; use varied inputs to reveal edge cases
 5. **Monitor for timeouts** - Long tool operations may timeout
-6. **Never re-trigger on timeout or pending_approval** - Use `relevance_get_task_view` to poll instead
-7. **Report issues** - If a tool call fails unexpectedly or the agent behaves incorrectly, submit a report via `POST /bugs/submit` (see [report-bugs.md](report-bugs.md))
+6. **Never re-trigger on timeout or pending_approval** - Use `relevance_get_agent_task_summary` to poll instead
+7. **Report issues proactively** — if a tool call fails unexpectedly, the agent misbehaves, or you spot a "we should add X" gap, call `relevance_submit_feedback` immediately with the matching `category`. See [report-bugs.md](report-bugs.md) for the call shape.

--- a/plugins/relevance-ai/skills/managing-relevance-agents/system-prompts.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/system-prompts.md
@@ -1,6 +1,31 @@
+---
+title: Writing System Prompts
+description: Write effective agent system prompts — inline `{{_actions.<id>}}` pill placement, formatting rules (no markdown tables), role/scope/output structure, and common pitfalls. Load when authoring or revising an agent's system prompt.
+---
+
 # Writing System Prompts
 
 Best practices for writing effective agent system prompts.
+
+## Formatting Rules
+
+Use bullets, numbered lists, or `key: value` lines for structure. **Never use markdown tables** (pipe-delimited rows like `| col1 | col2 |` followed by `| --- | --- |`) — the prompt editor cannot render them and they appear to the agent (and the user editing the prompt) as raw pipe characters.
+
+Replace tables with bullet lists or arrow-style key-value lines:
+
+```markdown
+# BAD — renders as raw pipes in the prompt editor
+
+| Category  | Route               |
+| --------- | ------------------- |
+| Billing   | billing@example.com |
+| Technical | support@example.com |
+
+# GOOD — renders cleanly
+
+- Billing → billing@example.com
+- Technical → support@example.com
+```
 
 ## Basic Structure
 
@@ -29,13 +54,44 @@ When the user asks about [topic]:
 
 ## Referencing Tools
 
-Use `{{_actions.ACTION_ID}}` to reference tools in prompts. The `ACTION_ID` is a backend-generated hex string.
+Use `{{_actions.ACTION_ID}}` to reference tools in prompts. The `ACTION_ID` is a backend-generated 16-char hex string. The runtime substitutes each pill for the real function-call name; the editor renders them as clickable pill chips.
+
+### Inline Placement (Required)
+
+Weave `{{_actions.<id>}}` pills inline into the prose at every point where the prompt directs the agent to use a specific tool — not just in a trailing reference block. Inline pills give the LLM a strong tool-selection cue at decision time; a trailing reference list alone is much weaker.
+
+`relevance_attach_tools_to_agent` (with `inject_action_references=true`, the default) auto-appends a `## Tool References` block listing every tool. That block is reference data and a fallback — leave it on, but follow up with `relevance_update_agent` to add inline pills in the prose ABOVE it.
+
+```markdown
+# GOOD — pills woven inline alongside the trailing reference block
+
+When the user asks a research question:
+
+1. Use {{_actions.abc123def4567890}} to search for sources.
+2. For promising results, use {{_actions.fedcba0987654321}} to extract content.
+
+## Tool References
+
+- **Search Tool**: {{_actions.abc123def4567890}}
+- **Extract Tool**: {{_actions.fedcba0987654321}}
+```
+
+```markdown
+# BAD — pills only in the trailing block; the prose gives the LLM no selection cue
+
+When the user asks a research question, search for sources and extract content.
+
+## Tool References
+
+- **Search Tool**: {{_actions.abc123def4567890}}
+- **Extract Tool**: {{_actions.fedcba0987654321}}
+```
 
 ### Getting Action IDs
 
 ```typescript
 // Fetch the actual action_ids
-const tools = await relevance_get_agent_tools({ agentId: '...' });
+const tools = await relevance_get_agent_tools({ agent_id: '...' });
 // Returns: { chains: [{ studio_id: "my-tool", action_id: "abc123def456" }] }
 
 // Use in system prompt:

--- a/plugins/relevance-ai/skills/managing-relevance-agents/triggers.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/triggers.md
@@ -1,3 +1,8 @@
+---
+title: Agent Triggers
+description: Configure event-driven and scheduled triggers (webhooks, email, Slack, LinkedIn, schedules) that feed agents work. Load when setting up automation or choosing between polling and push triggers.
+---
+
 # Agent Triggers
 
 Configure agents to respond to external events.
@@ -157,16 +162,16 @@ Is this time-based work (reports, digests, monitoring)?
 ### List Agent Triggers
 
 ```typescript
-relevance_list_agent_triggers({ agentId: '...' });
+relevance_list_agent_triggers({ agent_id: '...' });
 ```
 
 ### Create Trigger
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'gmail',
-  config: {
+  agent_id: '...',
+  trigger_type: 'gmail',
+  trigger_config: {
     oauth_account_id: '...',
     oauth_account_label: 'My Gmail',
   },
@@ -176,7 +181,7 @@ relevance_create_trigger({
 ### Delete Trigger
 
 ```typescript
-relevance_delete_trigger({ documentId: 'trigger-doc-id' });
+relevance_delete_trigger({ document_id: 'trigger-doc-id' });
 ```
 
 ## Trigger Configurations
@@ -185,9 +190,9 @@ relevance_delete_trigger({ documentId: 'trigger-doc-id' });
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'gmail', // or "outlook"
-  config: {
+  agent_id: '...',
+  trigger_type: 'gmail', // or "outlook"
+  trigger_config: {
     oauth_account_id: 'oauth-account-uuid',
     oauth_account_label: 'Work Gmail', // optional
   },
@@ -198,9 +203,9 @@ relevance_create_trigger({
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'unipile_linkedin',
-  config: {
+  agent_id: '...',
+  trigger_type: 'unipile_linkedin',
+  trigger_config: {
     oauth_account_id: '...',
     provider_user_id: '...', // LinkedIn user ID
     is_outreach_reply_only: false, // true = only reply to outreach
@@ -212,11 +217,96 @@ relevance_create_trigger({
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'unipile_whatsapp', // or "unipile_telegram"
-  config: {
+  agent_id: '...',
+  trigger_type: 'unipile_whatsapp', // or "unipile_telegram"
+  trigger_config: {
     oauth_account_id: '...',
     provider_user_id: '...',
+  },
+});
+```
+
+### Slack Trigger
+
+Listens for messages in specific Slack channels.
+
+**Setup steps:**
+
+1. Find Slack OAuth account: `relevance_list_oauth_accounts()`
+2. Resolve channel names to IDs: `relevance_list_slack_channels({ oauth_account_id: "..." })`
+3. Create the trigger
+
+```typescript
+relevance_create_trigger({
+  agent_id: '...',
+  trigger_type: 'slack',
+  trigger_config: {
+    oauth_account_id: 'slack-oauth-account-uuid',
+    channels: ['C07AGHNGV9Q'], // Channel IDs from relevance_list_slack_channels
+    keywords: {
+      // Optional: only trigger on matching messages
+      values: ['help', 'support'],
+      config: { case_sensitive: false },
+    },
+    user_ids: [], // Optional: filter to specific Slack user IDs
+    thread_reply_mode: 'auto', // 'auto' = reply in thread, 'none' = new message
+    should_mention_bot: true, // true = only when @mentioned
+  },
+});
+```
+
+**Notes:**
+
+- `channels` requires Slack channel **IDs** (e.g. `C07AGHNGV9Q`), not names. Use `relevance_list_slack_channels` to look up IDs.
+- Set `should_mention_bot: false` to respond to every message in the channel.
+- `keywords` is optional — omit or pass `{ values: [] }` to match all messages.
+
+### Google Calendar Trigger
+
+Triggers the agent on calendar events (e.g., upcoming meetings).
+
+```typescript
+relevance_create_trigger({
+  agent_id: '...',
+  trigger_type: 'google_calendar',
+  trigger_config: {
+    oauth_account_id: 'google-oauth-account-uuid',
+    calendar_id: 'primary', // 'primary' or a specific calendar ID
+    events: {
+      notifications: [
+        {
+          timeOffset: {
+            quantity: 10,
+            unit: 'minutes',
+            direction: 'before',
+          },
+          message: { type: 'raw' },
+        },
+      ],
+    },
+  },
+});
+```
+
+### Teams Trigger
+
+Listens for messages in Microsoft Teams channels.
+
+```typescript
+relevance_create_trigger({
+  agent_id: '...',
+  trigger_type: 'teams',
+  trigger_config: {
+    oauth_account_id: 'teams-oauth-account-uuid',
+    tenant_id: 'microsoft-tenant-id',
+    channels: [],
+    keywords: {
+      values: [],
+      config: { case_sensitive: false },
+    },
+    excluded_keywords: [],
+    thread_reply_mode: 'auto',
+    should_mention_bot: true,
   },
 });
 ```
@@ -241,9 +331,9 @@ Schedule agents to run automatically at specified intervals.
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'recurring',
-  config: {
+  agent_id: '...',
+  trigger_type: 'recurring',
+  trigger_config: {
     name: 'Check LinkedIn Comments',
     message: 'Process this LinkedIn post: 123456789',
     schedule: {
@@ -260,9 +350,9 @@ relevance_create_trigger({
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'recurring',
-  config: {
+  agent_id: '...',
+  trigger_type: 'recurring',
+  trigger_config: {
     name: 'Daily Report',
     message: 'Generate the daily sales report',
     schedule: {
@@ -278,9 +368,9 @@ relevance_create_trigger({
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'recurring',
-  config: {
+  agent_id: '...',
+  trigger_type: 'recurring',
+  trigger_config: {
     name: 'Weekly Summary',
     message: 'Generate weekly metrics summary',
     schedule: {
@@ -297,9 +387,9 @@ relevance_create_trigger({
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'recurring',
-  config: {
+  agent_id: '...',
+  trigger_type: 'recurring',
+  trigger_config: {
     name: 'Business Hours Check',
     message: 'Run health check',
     schedule: {
@@ -320,9 +410,9 @@ There are two webhook trigger types. **Use `custom_webhook` for most integration
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'custom_webhook',
-  config: {
+  agent_id: '...',
+  trigger_type: 'custom_webhook',
+  trigger_config: {
     webhook_name: 'Zapier Webhook', // optional: display name
     webhook_description: 'Receives form submissions', // optional: description
     message_template: '{{$}}', // required: template for agent message
@@ -341,9 +431,9 @@ Use when you just need a URL to POST to with no message transformation.
 
 ```typescript
 relevance_create_trigger({
-  agentId: '...',
-  triggerType: 'webhook',
-  config: {}, // Returns webhook URL to call
+  agent_id: '...',
+  trigger_type: 'webhook',
+  trigger_config: {}, // Returns webhook URL to call
 });
 ```
 
@@ -381,11 +471,11 @@ For Unipile triggers (LinkedIn/WhatsApp/Telegram), you also need `provider_user_
 Triggers are identified by document IDs. Get these from `relevance_list_agent_triggers`:
 
 ```typescript
-const triggers = await relevance_list_agent_triggers({ agentId: '...' });
+const triggers = await relevance_list_agent_triggers({ agent_id: '...' });
 // triggers.results[0].document_id = "agentId_gmail_oauthId"
 
 // Use to delete
-relevance_delete_trigger({ documentId: 'agentId_gmail_oauthId' });
+relevance_delete_trigger({ document_id: 'agentId_gmail_oauthId' });
 ```
 
 ## Example: Email Assistant Setup
@@ -397,9 +487,9 @@ const gmail = accounts.results.find((a) => a.provider === 'google');
 
 // 2. Create email trigger
 relevance_create_trigger({
-  agentId: 'email-assistant',
-  triggerType: 'gmail',
-  config: {
+  agent_id: 'email-assistant',
+  trigger_type: 'gmail',
+  trigger_config: {
     oauth_account_id: gmail.account_id,
   },
 });
@@ -416,9 +506,9 @@ const linkedin = accounts.results.find(
 
 // 2. Create LinkedIn trigger
 relevance_create_trigger({
-  agentId: 'linkedin-bot',
-  triggerType: 'unipile_linkedin',
-  config: {
+  agent_id: 'linkedin-bot',
+  trigger_type: 'unipile_linkedin',
+  trigger_config: {
     oauth_account_id: linkedin.account_id,
     provider_user_id: linkedin.provider_user_id,
     is_outreach_reply_only: true, // Only respond to outreach replies

--- a/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
+++ b/plugins/relevance-ai/skills/managing-relevance-agents/troubleshooting.md
@@ -1,3 +1,8 @@
+---
+title: Troubleshooting Agents
+description: Diagnose common agent failures — draft vs live confusion, region mismatches, `action_behaviour` blocking, autonomy limits, trigger failures. Load when an agent is misbehaving or a tool/trigger isn't running as expected.
+---
+
 # Troubleshooting Agents
 
 Common issues and fixes for Relevance AI agents.
@@ -24,29 +29,17 @@ Step N: API call        Step 0: Agent/Trigger
 
 ## Critical Issues
 
-### `relevance_save_agent_draft` Warns About Empty Actions
+### Edits Don't Show Up in Production — Draft Wasn't Published
 
-**Symptom:** Saving an agent returns a warning about `actions` being empty.
+**Symptom:** You called `relevance_update_agent` or `relevance_attach_tools_to_agent`, the call succeeded, but production behaviour hasn't changed.
 
-**Cause:** The `relevance_save_agent_draft` API uses PUT semantics — omitted fields get wiped. The warning helps catch accidental omissions (e.g. forgetting to include existing tools).
+**Cause:** Those tools save to a DRAFT only. The active version is still the previously-published one (or undefined if `relevance_create_agent` hasn't been published yet).
 
-**When it's safe to ignore:** If the agent intentionally has no tools, the warning is a false positive. The save still proceeds — it's a warning, not a block.
+**Fix:** Confirm with the user, then call `relevance_publish_agent({ agent_id })`. The publish tool always shows an approval card (even with auto-approve enabled) — that's intentional.
 
-**When to act:** If the agent should have tools, fetch the full config first:
+**Inspecting state:** Call `relevance_get_agent` and check `has_unpublished_draft`, `active_version_id`, and `draft_version_id` on the response.
 
-```typescript
-// Fetch full config, merge your changes, save complete object
-const { agent } = await relevance_get_agent({
-  agent_id: '...',
-  summary: false,
-});
-await relevance_save_agent_draft({
-  agent_id: '...',
-  config: { ...agent, system_prompt: 'updated prompt' },
-});
-```
-
-**Tip:** For targeted edits (system prompt, model, etc.), use `relevance_patch_agent` instead — it handles fetch/merge/save internally and avoids this issue entirely.
+**Testing the draft without publishing:** Call `relevance_trigger_agent` — it defaults to the draft when one exists. The response's `triggered_version` field tells you which version actually ran. Pass `version: "draft"` to be explicit.
 
 ### Agent Max Output Tokens — 422 Error
 
@@ -54,40 +47,7 @@ await relevance_save_agent_draft({
 
 **Cause:** `max_output_tokens` is NOT a top-level agent field — it lives inside `model_options`.
 
-**Fix:**
-
-```typescript
-// WRONG — 422 error
-{ ...agent, max_output_tokens: 16000 }
-
-// CORRECT — nested inside model_options
-{ ...agent, model_options: { max_output_tokens: 16000 } }
-```
-
-See [creating.md](creating.md) for the full `model_options` reference.
-
-### Agent Config Wiped After Update
-
-**Symptom:** Agent lost system prompt, tools, or other config after saving.
-
-**Cause:** `relevance_save_agent_draft` does NOT support partial updates.
-
-**Fix:**
-
-```typescript
-// WRONG - wipes everything not included
-relevance_save_agent_draft({
-  agentId: 'xxx',
-  agentConfig: { emoji: 'new' },
-});
-
-// CORRECT - get first, merge, save all
-const { agent } = await relevance_get_agent({ agentId: 'xxx' });
-relevance_save_agent_draft({
-  agentId: 'xxx',
-  agentConfig: { ...agent, emoji: 'new' },
-});
-```
+**Fix:** Call `relevance_update_agent` with `patch: { model_options: { max_output_tokens: 16000 } }`. See [creating.md](creating.md) for the full `model_options` reference.
 
 ### Agent Says "I'll Run the Tool" But Nothing Happens
 
@@ -95,19 +55,7 @@ relevance_save_agent_draft({
 
 **Cause:** `action_behaviour` is set to `"always-ask"`, which requires user approval before each tool call.
 
-**Fix:**
-
-```typescript
-{
-  action_behaviour: "never-ask",  // At agent level
-  actions: [
-    {
-      chain_id: "my-tool",
-      action_behaviour: "never-ask"  // Per-tool level
-    }
-  ]
-}
-```
+**Fix:** Call `relevance_update_agent_action` with the tool's `chain_id` and `patch: { action_behaviour: "never-ask" }`. The agent-level `action_behaviour` set via `relevance_update_agent` is a fallback default — most cases need the per-tool override.
 
 ### Agent Runs Tool Then Silently Stops
 
@@ -115,38 +63,15 @@ relevance_save_agent_draft({
 
 **Cause:** `autonomy_limit_behaviour: "terminate-conversation"` causes the agent to silently end instead of responding after reaching its limit.
 
-**Fix:**
-
-```typescript
-{
-  autonomy_limit: 25,
-  autonomy_limit_behaviour: "ask-for-approval"  // NOT "terminate-conversation"
-}
-```
-
-With `"ask-for-approval"`, the agent will pause and ask to continue rather than silently stopping.
+**Fix:** Call `relevance_update_agent` with `patch: { autonomy_limit: 25, autonomy_limit_behaviour: "ask-for-approval" }`. The agent will then pause and ask to continue rather than silently stopping.
 
 ### Tools Not Executing
 
 **Symptom:** Agent acknowledges tools but doesn't use them, or tool calls fail.
 
-**Cause 1:** Missing `project` and `region` in action config.
+**Cause 1:** Missing `project` and `region` in action config. `relevance_attach_tools_to_agent` sets these automatically — if they're missing, the action was likely added by hand and is broken. Re-attach with `relevance_attach_tools_to_agent`, or call `relevance_update_agent_action` with `patch: { project, region }`.
 
-**Fix:**
-
-```typescript
-{
-  chain_id: "my-tool",
-  project: config.project,    // REQUIRED
-  region: config.region,      // REQUIRED
-  title: "My Tool",
-  action_behaviour: "never-ask"
-}
-```
-
-**Cause 2:** Tool is disabled.
-
-**Fix:** Check `disabled: false` in action config.
+**Cause 2:** Tool is disabled. Call `relevance_update_agent_action` with `patch: { disabled: false }`.
 
 **Cause 3:** `action_behaviour: "always-ask"` blocking execution (see above).
 
@@ -156,13 +81,7 @@ With `"ask-for-approval"`, the agent will pause and ask to continue rather than 
 
 **Cause:** Using wrong action ID.
 
-**Fix:** Use backend-generated IDs, not your custom IDs:
-
-```typescript
-// Get the real action IDs
-const tools = await relevance_get_agent_tools({ agentId: '...' });
-// Use actionIdMap values in system prompt
-```
+**Fix:** Use backend-generated IDs, not your custom IDs. Call `relevance_get_agent_tools` and read the `actionIdMap` values into your system prompt.
 
 ### Agent Cloning Fails with "additional properties" Error
 
@@ -170,7 +89,7 @@ const tools = await relevance_get_agent_tools({ agentId: '...' });
 
 **Cause:** Phantom tools (e.g., `thinking_tool`, `add_agent_memory`) leaked into the agent's `actions` array, bringing invalid fields like `studio_id`, `transformations`, `action_config`.
 
-**Fix:** Re-save the agent using `relevance_save_agent_draft` — the MCP automatically strips phantom tools on save. See [phantom-tools.md](phantom-tools.md) for details.
+**Fix:** Re-save the agent using `relevance_update_agent` (passing any small change to trigger a save) or `relevance_attach_tools_to_agent` — the MCP automatically strips phantom tools on save. See [phantom-tools.md](phantom-tools.md) for details.
 
 ### Agent Cloning Fails (Missing Fields)
 
@@ -186,42 +105,13 @@ const tools = await relevance_get_agent_tools({ agentId: '...' });
 
 **Cause:** Wrong `region` in action config. The region must match where the tool exists, not your project's region.
 
-**Diagnosis:**
-
-```typescript
-// Check if tools attached
-const tools = await relevance_get_agent_tools({ agentId: '...' });
-if (tools.chains.length === 0) {
-  // Tools not attached - likely region mismatch
-}
-```
+**Diagnosis:** Call `relevance_get_agent_tools` — if `chains` comes back empty even though actions are attached, it's almost always a region mismatch.
 
 **Fix:**
 
-1. Find correct region from a working agent or tool:
-
-```typescript
-// Option 1: Check a working agent that uses the same tool
-const agents = await relevance_list_agents({ pageSize: 5 });
-// Look at actions[].region in agents that work
-
-// Option 2: The tool metadata often shows source region
-const tool = await relevance_get_tool({ studioId: 'tool-id' });
-// Check tool.studio.metadata.source_marketplace_listing.entity_region
-```
-
-2. Update actions with correct region:
-
-```typescript
-actions: [{
-  chain_id: "tool-id",
-  region: "f1db6c",  // Correct region from above
-  project: "your-project-id",
-  ...
-}]
-```
-
-3. Re-save and publish the agent.
+1. Find the correct region. Either run `relevance_list_agents` and read `actions[].region` from a working agent that uses the same tool, OR call `relevance_get_tool` and check `studio.metadata.source_marketplace_listing.entity_region`.
+2. Call `relevance_update_agent_action` with the broken tool's `chain_id` and `patch: { region: "<correct>" }`.
+3. Confirm with the user, then call `relevance_publish_agent`.
 
 ## Trigger Issues
 
@@ -271,7 +161,7 @@ actions: [{
 **Fix:**
 
 1. Go to the conversation URL returned in the response to approve/reject the pending tool call
-2. For automated/MCP use, call `relevance_patch_agent` to change the tool's `action_behaviour` to `"never-ask"`
+2. For automated/MCP use, call `relevance_update_agent` to change the tool's `action_behaviour` to `"never-ask"`
 
 ### Duplicate Tasks Created
 
@@ -279,7 +169,7 @@ actions: [{
 
 **Cause:** Re-triggering the agent after a timeout or pending_approval. The original task is still running server-side.
 
-**Fix:** Never re-trigger. Instead, use `relevance_get_task_view` with the original `conversation_id` to check status. The `relevance_trigger_agent` tool returns `timed_out` or `pending_approval` as informational statuses, not errors.
+**Fix:** Never re-trigger. Instead, use `relevance_get_agent_task_summary` with the original `conversation_id` to check status. The `relevance_trigger_agent` tool returns `timed_out` or `pending_approval` as informational statuses, not errors.
 
 ### Agent Stuck/Not Responding
 
@@ -300,20 +190,6 @@ actions: [{
 
 ## Configuration Issues
 
-### Fields That Get Wiped If Not Included
-
-When using `relevance_save_agent_draft`, these are wiped if omitted:
-
-- `system_prompt`
-- `actions`
-- `emoji`
-- `model`
-- `temperature`
-- `params_schema`
-- `description`
-
-**Always fetch and merge before saving.**
-
 ### Model Not Available
 
 **Symptom:** Error about model not found.
@@ -329,7 +205,7 @@ When using `relevance_save_agent_draft`, these are wiped if omitted:
 
 ### 1. Check Agent Config
 
-Inspect the full agent config returned by `relevance_get_agent({ agentId: "..." })`.
+Inspect the full agent config returned by `relevance_get_agent({ agent_id: "..." })`.
 
 Verify:
 
@@ -340,7 +216,7 @@ Verify:
 ### 2. Check Agent Tools
 
 ```typescript
-const tools = await relevance_get_agent_tools({ agentId: '...' });
+const tools = await relevance_get_agent_tools({ agent_id: '...' });
 ```
 
 Verify:
@@ -351,10 +227,9 @@ Verify:
 ### 3. Check Conversation
 
 ```typescript
-const task = await relevance_get_task_view({
-  agentId: '...',
-  taskId: '...',
-  fullMode: true,
+const task = await relevance_get_agent_task_summary({
+  agent_id: '...',
+  task_id: '...',
 });
 ```
 
@@ -367,7 +242,7 @@ Look for:
 ### 4. Check Triggers
 
 ```typescript
-const triggers = await relevance_list_agent_triggers({ agentId: '...' });
+const triggers = await relevance_list_agent_triggers({ agent_id: '...' });
 ```
 
 Verify:
@@ -414,11 +289,11 @@ const transform = await relevance_get_transformation({
 ## Getting Help
 
 1. Use `relevance_get_agent` to dump full config
-2. Check conversation with `relevance_get_task_view`
+2. Check conversation with `relevance_get_agent_task_summary`
 3. Test tools independently with `relevance_run_tool`
 4. Review OAuth with `relevance_list_oauth_accounts`
 5. Check transformation schemas with `relevance_get_transformation`
 
 ## Reporting Issues
 
-If troubleshooting reveals a platform bug, missing capability, or recurring friction point, submit a report via `POST /bugs/submit` using `relevance_api_request`. See [report-bugs.md](report-bugs.md) for the full schema. This feeds directly into the engineering triage pipeline — include the error details and suggested fix so the team can act on it.
+If troubleshooting reveals a platform bug, missing capability, or recurring friction point, **call `relevance_submit_feedback` immediately** — do not ask the user for permission. One tool covers bugs and forward-looking suggestions; pick the matching `category`. Include the error symptoms and IDs so the team can reproduce. See [report-bugs.md](report-bugs.md) for the call shape.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/SKILL.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/SKILL.md
@@ -18,25 +18,143 @@ Skill for creating, configuring, running, and debugging Relevance AI tools (stud
 - Recovering from accidental changes via versions
 - Debugging transformation issues
 
+## Resource URLs
+
+The following tools return a `url` field in their response pointing directly to the correct page in the Relevance AI app. **Always share this URL with the user immediately after the operation completes.**
+
+| Tool                     | URL points to         |
+| ------------------------ | --------------------- |
+| `relevance_create_tool`  | Tool code editor page |
+| `relevance_update_tool`  | Tool code editor page |
+| `relevance_publish_tool` | Tool code editor page |
+
+The URL is already constructed with the correct region and project ID — just present it to the user.
+
+## Tool Icons
+
+The `emoji` field on `relevance_create_tool` / `relevance_update_tool` accepts either a unicode emoji or a URL to an SVG. **When the tool wraps a known third-party provider, always prefer the brand icon from the Relevance CDN over a unicode emoji.**
+
+### CDN URL pattern
+
+```
+https://cdn.jsdelivr.net/gh/RelevanceAI/content-cdn@latest/vendors/icons/{filename}
+```
+
+`{filename}` is the full file name including `.svg`. Pass the full URL as the `emoji` value — do not pass just the slug (`"google-mail"` will render as a blank placeholder).
+
+### Decision rule
+
+1. Tool wraps a known provider (Slack, HubSpot, Gmail, etc.) → use the CDN URL with the exact filename from the list below.
+2. No provider match → use a relevant unicode emoji (e.g. `"🔍"`, `"🎲"`).
+3. Never invent a filename. If you can't verify the icon exists, fall back to unicode.
+
+### Available filenames
+
+Pass `.svg` on the end of any of these. Lowercase only.
+
+```
+airtable, anthropic, apollo, ashby, avoma, bigquery, brightdata, browserless,
+calendar, canva, cohere, confluence, database, databricks, facebook, file,
+firecrawl, gamma, github, gong, google, google-calendar, google-docs,
+google-drive, google-gemini, google-mail, google-sheets, groq, hubspot,
+huggingface, instagram, jira, key-command, linear, linkedin, microsoft-outlook,
+microsoft_onedrive, microsoft_teams, mistral, monday, mysql, notion, openai,
+openrouter, outreach, perplexity, postgres, redis, relevance, replicate,
+salesforce, salesloft, sendgrid, serpapi, serper, sharepoint, slack, snowflake,
+supabase, tavily, telegram, trello, twilio, twitter, webflow, webhook,
+whatsapp, x, xai, youtube, zoho_crm, zoom, zoominfo
+```
+
+### Non-obvious filenames (common mistakes)
+
+| If you're thinking… | The actual filename is…               |
+| ------------------- | ------------------------------------- |
+| `gmail`             | `google-mail.svg`                     |
+| `outlook`           | `microsoft-outlook.svg` (hyphen)      |
+| `teams`             | `microsoft_teams.svg` (underscore)    |
+| `onedrive`          | `microsoft_onedrive.svg` (underscore) |
+| `zoho` / `zohocrm`  | `zoho_crm.svg` (underscore)           |
+
+### Worked example
+
+```typescript
+relevance_create_tool({
+  title: 'Send Slack message',
+  description: 'Post a message to a Slack channel',
+  emoji:
+    'https://cdn.jsdelivr.net/gh/RelevanceAI/content-cdn@latest/vendors/icons/slack.svg',
+  // ...rest of config
+});
+```
+
+## Tools vs Agents: When NOT to Create a Tool
+
+Tools are for **external integrations and side effects** — actions that interact with systems outside the agent (APIs, databases, email services, CRM, web scraping, file storage). They are NOT for wrapping core reasoning tasks.
+
+**Create a tool when the task involves:**
+
+- Calling an external API (Google Search, SendGrid, Slack, CRM)
+- Reading/writing to a database or knowledge table
+- Performing a deterministic transformation (parsing, formatting, calculations)
+- Interacting with third-party services (OAuth integrations)
+
+**Do NOT create a tool when the task is pure reasoning/intelligence:**
+
+- Scoring or evaluating something (e.g., "Score this lead 1-100")
+- Drafting or writing content (e.g., "Write an outreach email")
+- Analyzing or summarizing information
+- Making decisions or classifications
+
+> **If a tool's only transformation step is `prompt_completion`, it should almost certainly be an agent instead.**
+> That reasoning belongs in the agent's system prompt, or in a dedicated sub-agent within a workforce.
+>
+> **Exception:** Tools that combine API calls with LLM processing steps are fine — e.g., a tool that scrapes a webpage, then uses `prompt_completion` to extract structured data. The key is that the tool does something an agent can't (call an API), and the LLM step processes the result. A tool that is _only_ an LLM call adds no value over an agent.
+>
+> See [Workforce Documentation](../managing-relevance-workforces/SKILL.md) for building multi-agent systems where each agent handles a distinct reasoning task.
+
+### Example: Sales Lead Pipeline
+
+**Reasoning tasks → use agents, not tools:**
+
+| Task                 | ❌ Wrong: Tool with LLM step                     | ✅ Right: Agent in workforce                                   |
+| -------------------- | ------------------------------------------------ | -------------------------------------------------------------- |
+| Score a lead         | Tool with `prompt_completion` that scores leads  | **Lead Qualifier agent** with scoring logic in system prompt   |
+| Draft outreach email | Tool with `prompt_completion` that writes emails | **Outreach Drafter agent** with email writing in system prompt |
+
+**Integration tasks → correctly tools (attached to agents):**
+
+| Task                 | Correct implementation              |
+| -------------------- | ----------------------------------- |
+| Look up company data | Tool calling Clearbit/LinkedIn API  |
+| Send email           | Tool calling SendGrid/email API     |
+| Update CRM           | Tool calling Salesforce/HubSpot API |
+
+The agents handle reasoning; tools handle external actions. In evals, you simulate the external tools (Clearbit, SendGrid) while testing the agents' actual reasoning.
+
 ## MCP Tools
 
-| Tool                                        | Description                                                 |
-| ------------------------------------------- | ----------------------------------------------------------- |
-| `relevance_list_tools`                      | List all tools in project                                   |
-| `relevance_get_tool`                        | Get full tool config                                        |
-| `relevance_upsert_tool`                     | Create or update a tool (auto-generates UUID for new tools) |
-| `relevance_create_tool_from_transformation` | Create tool from transformation with auto-generated config  |
-| `relevance_publish_tool`                    | Publish tool draft                                          |
-| `relevance_run_tool`                        | Execute tool synchronously                                  |
-| `relevance_trigger_tool_async`              | Execute tool asynchronously                                 |
-| `relevance_poll_tool_result`                | Poll async job status                                       |
-| `relevance_get_latest_tool_run`             | Get latest run ID                                           |
-| `relevance_list_tool_versions`              | List version history for a tool                             |
-| `relevance_get_tool_version`                | Get a specific version's config                             |
-| `relevance_restore_tool_version`            | Restore a tool to a previous version                        |
-| `relevance_search_public_tools`             | Search community/public tools                               |
-| `relevance_clone_public_tool`               | Clone a public tool into your project                       |
-| `relevance_api_request`                     | Raw API fallback for uncovered endpoints                    |
+| Tool                                        | Description                                                                            |
+| ------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `relevance_list_tools`                      | List all tools in project                                                              |
+| `relevance_get_tool`                        | Get full tool config (accepts `version` for draft inspection)                          |
+| `relevance_create_tool`                     | Create a NEW tool — saves to DRAFT only; call `relevance_publish_tool` to make it live |
+| `relevance_update_tool`                     | Update an existing tool — saves to DRAFT only                                          |
+| `relevance_add_tool_step`                   | Add a transformation step (0-based `position`, defaults to append) — saves to DRAFT    |
+| `relevance_update_tool_step`                | Shallow-merge a patch into the step at 0-based `step_index` — saves to DRAFT           |
+| `relevance_remove_tool_step`                | Remove the step at 0-based `step_index` — saves to DRAFT                               |
+| `relevance_move_tool_step`                  | Reorder a step from `from_index` to `to_index` (0-based) — saves to DRAFT              |
+| `relevance_create_tool_from_transformation` | Create tool from transformation with auto-generated config                             |
+| `relevance_publish_tool`                    | Publish tool draft. Always shows an approval card.                                     |
+| `relevance_run_tool`                        | Execute tool synchronously (accepts `version` for testing the draft)                   |
+| `relevance_trigger_tool_async`              | Execute tool asynchronously (accepts `version`)                                        |
+| `relevance_poll_tool_result`                | Poll async job status                                                                  |
+| `relevance_get_latest_tool_run`             | Get latest run ID                                                                      |
+| `relevance_list_tool_versions`              | List version history for a tool                                                        |
+| `relevance_get_tool_version`                | Get a specific version's config                                                        |
+| `relevance_restore_tool_version`            | Restore a tool to a previous version (creates a draft)                                 |
+| `relevance_search_public_tools`             | Search community/public tools                                                          |
+| `relevance_clone_public_tool`               | Clone a public tool into your project                                                  |
+| `relevance_api_request`                     | Raw API fallback for uncovered endpoints                                               |
 
 ## Finding the Right Tool: Search Order
 
@@ -53,24 +171,26 @@ When looking for tools to accomplish a task, follow this search order:
 
 ### Underlying API: NO PARTIAL UPDATES
 
-The Relevance API does NOT support partial updates - any field you omit will be WIPED. However, the MCP tools handle this automatically:
+The Relevance API does NOT support partial updates — any field you omit will be WIPED. The MCP tools handle this automatically:
 
-- **Creating new tools (no `studio_id`)**: Just provide your fields, MCP adds defaults
-- **Updating existing tools (with `studio_id`)**: MCP auto-fetches existing config and merges your changes
+- **`relevance_create_tool`**: Just provide your fields, MCP adds defaults. Saves to a draft only — call `relevance_publish_tool` to make it live.
+- **`relevance_update_tool`**: MCP auto-fetches the existing draft config and merges your changes. Saves to draft only — call `relevance_publish_tool` when ready.
 
 ```typescript
 // Creating new tool - just provide what you need
-relevance_upsert_tool({
-  title: "My Tool",  // REQUIRED for new tools
+relevance_create_tool({
+  title: "My Tool",  // REQUIRED
   transformations: { steps: [...] }
 })
-// Returns { studio_id: "auto-uuid", created: true }
+// Returns { studio_id: "auto-uuid", url: "..." }
+// (saved as DRAFT — call relevance_publish_tool to make it live)
 
-// Updating existing tool - MCP auto-merges
-relevance_upsert_tool({
+// Updating existing tool - MCP auto-merges into the draft
+relevance_update_tool({
   studio_id: "my-tool",
   emoji: "new-emoji"  // Only this changes, rest preserved
 })
+// Returns { studio_id, url } — draft only; call publish_tool to go live.
 ```
 
 ### Creating Tools from Transformations
@@ -111,8 +231,7 @@ items: '{{llm_step.answer}}'; // WRONG - string
 ## Quick Start: Create Tool
 
 ```typescript
-relevance_upsert_tool({
-  studio_id: 'my-search-tool',
+relevance_create_tool({
   title: 'Search and Summarize',
   description: 'Search web and summarize results',
   prompt_description: 'Use this to search for information',
@@ -152,9 +271,12 @@ relevance_upsert_tool({
 - [transformations.md](transformations.md) - Implementation details, output patterns, and gotchas
 - [patterns.md](patterns.md) - Common patterns (search+analyze, loops)
 - [oauth.md](oauth.md) - OAuth account configuration
+- [api-keys.md](api-keys.md) - Detecting missing API keys and deep-linking users to the right integrations drawer
 - [running.md](running.md) - Running and testing tools
 - [versions.md](versions.md) - Version history and recovery
 - [reference.md](reference.md) - API auth, base URLs, discovering transformations
+
+For organizing tools into folders, see the [`managing-relevance-folders`](../managing-relevance-folders/SKILL.md) skill.
 
 ## URL Patterns
 
@@ -170,12 +292,12 @@ https://app.relevanceai.com/form/{region}/{project}/clone/tool/{studioId}
 
 If you accidentally wipe a tool:
 
-1. `relevance_list_tool_versions({ toolId: "my-tool" })` — Find a version with transformations intact
-2. `relevance_restore_tool_version({ versionId: "working-version-uuid" })` — Creates a new draft from that version
-3. `relevance_publish_tool({ toolId: "my-tool" })` — Publish the restored draft
+1. `relevance_list_tool_versions({ tool_id: "my-tool" })` — Find a version with transformations intact
+2. `relevance_restore_tool_version({ version_id: "working-version-uuid" })` — Creates a new draft from that version
+3. `relevance_publish_tool({ tool_id: "my-tool" })` — Publish the restored draft
 
 See [versions.md](versions.md) for full details.
 
 ## Reporting Issues
 
-If you encounter tool creation failures, transformation errors, or missing capabilities, submit a report via `POST /bugs/submit` using `relevance_api_request`. See the [bug reporting guide](../managing-relevance-agents/report-bugs.md) for the full schema and guidelines.
+If you encounter tool creation failures, transformation errors, or missing capabilities, **call `relevance_submit_feedback` immediately** — do not ask the user for permission. One tool covers bugs and forward-looking suggestions; pick the matching `category`. See the [bug reporting guide](../managing-relevance-agents/report-bugs.md) for the call shape.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/api-keys.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/api-keys.md
@@ -1,0 +1,107 @@
+---
+title: API Key Integrations
+description: Detect, interpret, and resolve missing API-key integrations for Relevance tools via MCP. Use when agents' tools fail with "API key missing" errors, when attaching tools to an agent, or before triggering agents that depend on API-key providers.
+---
+
+# API Key Integrations
+
+Deep reference for API-key integrations. For the detection → setup → verify workflow and the OAuth-vs-API-key overview, see [integration-setup.md](integration-setup.md) first.
+
+## When to Check
+
+- **After `relevance_attach_tools_to_agent`** — its `integration_warnings.tools_needing_api_keys` lists any attached tool whose transformations require a key the project doesn't have.
+- **On "API key missing" errors** — runtime errors like `"You need to add your chains_xxx_api_key"` or `"Missing API key for provider: <name>"` mean the backend tried to read an unconfigured key.
+- **Before triggering an agent** — verify keys are in place so the run doesn't fail mid-conversation.
+
+Because the requirement lives on the underlying transformation, you cannot see it from the tool's `params_schema` alone — always use `relevance_check_tool_integration_requirements` (or `relevance_check_api_key_availability` for a project-wide read).
+
+> **Always show `provider_label` to the user, not `provider`.** The `provider` field is the internal identifier (e.g., `twilio_account_sid`, `aws-bedrock-iam-key-id`) — pass it through to other MCP calls and deep-link URLs, but never paste it into a user-facing message. Use `provider_label` (e.g., "Twilio Account SID") for anything the user will read. The label falls back to the raw identifier only when the provider is not in the catalog.
+
+## Project-level lookup
+
+To inspect what's configured across the project and org without going via a tool:
+
+```typescript
+relevance_check_api_key_availability({
+  providers: ['firecrawl', 'serper'], // optional filter
+});
+```
+
+Each entry in `api_keys[]` carries `key` (the internal identifier), `label` (the friendly display name — use this when talking to the user), `project_context.api_key_provided`, `organization_context.api_key_provided`, and a per-provider `setup_url`.
+
+## Interpreting `status`
+
+| Status                   | Meaning                                                               | What to tell the user                                                                                                  |
+| ------------------------ | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `configured`             | User (or their org) has saved a key for this provider.                | Nothing — the tool will work.                                                                                          |
+| `platform_key_available` | User has no key, but Relevance has a shared platform key as fallback. | Optional: "You can add your own key for higher rate limits and separate billing, but this tool will work without one." |
+| `missing`                | No user key **and** no platform fallback.                             | Required: direct the user to the `setup_url` for that provider.                                                        |
+
+## Messaging examples
+
+Each missing-key entry includes a `setup_url` that deep-links to the integrations page **with that provider's drawer already open** (via `?provider=<value>&type=api_key`). Prefer it over the generic `setup_url` at the top level.
+
+When exactly one key is missing (using `provider_label` from the response):
+
+> Your tool _"Firecrawl Scraper"_ needs a **Firecrawl API Key** before it can run. Add yours here: https://app.relevanceai.com/integrations/us-east/proj-xxx?provider=firecrawl&type=api_key
+
+When `has_platform_key: true`, frame it as optional:
+
+> _"Web Search"_ will use Relevance's shared **Serper API Key** by default. If you want your own (for separate rate limits or billing), add it here: https://app.relevanceai.com/integrations/us-east/proj-xxx?provider=serper&type=api_key
+
+After the user reports they've added the key, verify:
+
+```typescript
+relevance_check_api_key_availability({ providers: ['firecrawl'] });
+// expect project_context.api_key_provided: true
+```
+
+## Deep-link URL pattern
+
+The MCP tools always emit the `setup_url` for you. If you ever need to construct one manually, the pattern is:
+
+```
+{baseUrl}/integrations/{region}/{projectId}?provider={providerValue}&type=api_key
+```
+
+Opening this URL lands the user on the integrations page with the right provider drawer already expanded.
+
+## Multi-Key Providers
+
+Some providers are exposed as several independent key entries that must all be configured for the tool to work. The MCP returns one entry **per key** — treat each independently and send the user once per missing key. Each entry's `provider_label` will be human-readable (e.g., "Twilio Account SID", "Twilio Auth Token") — use those in your message to the user rather than the raw `provider` identifiers listed below.
+
+| Provider                       | Keys that appear together                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| Twilio                         | `twilio_account_sid`, `twilio_auth_token`                                                                           |
+| Postgres                       | `postgres-connection-string` (SSL keys are optional)                                                                |
+| AWS Bedrock                    | `aws-bedrock-iam-key-id`, `aws-bedrock-iam-secret-access-key`, `aws-bedrock-iam-region`, `aws-bedrock-iam-role-arn` |
+| Azure OpenAI                   | `azure-openai-key`, `azure-openai-url`, `azure-openai-model`                                                        |
+| Google Cloud (Vertex / Gemini) | `gcp_project`, `gcp_location`, `gcp_private_key`, `gcp_client_email`                                                |
+| Marketo                        | `marketo-client-id`, `marketo-client-secret`, `marketo-instance-url`                                                |
+| ZoomInfo                       | `zoom_info_email`, `zoom_info_clientid`, `zoom_info_private_key`                                                    |
+
+When you see multiple missing keys for the same provider family, ask the user to configure them as a set — the tool will still fail if only one is present.
+
+## LLM Provider Keys
+
+Keys for LLM vendors (`openai`, `anthropic`, `google`, `cohere`, `groq`, `xai`, `mistral`, `openrouter`, `fireworksai`, plus the BYO variants above) almost always return `has_platform_key: true`, meaning the tool will run fine without any user action. Avoid noisy prompts about adding an LLM key — only bring it up if:
+
+- The user explicitly asked to bring their own key (e.g. for separate billing or higher rate limits), or
+- `has_platform_key` is `false` (rare — usually an enterprise/self-hosted setup), in which case the user must add one.
+
+## Common Errors
+
+| Error string                                        | Cause                                                        | Fix                                                                                                              |
+| --------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `"You need to add your chains_xxx_api_key API key"` | Tool ran but the backing transformation couldn't find a key. | Run `relevance_check_tool_integration_requirements` on the tool to find the provider, then send the `setup_url`. |
+| `"Missing API key for provider: <name>"`            | Same as above, surfaced from the transformation layer.       | Same fix.                                                                                                        |
+| Tool silently errors with no useful message         | Most often a missing integration.                            | Always run `relevance_check_tool_integration_requirements` first when debugging tool failures.                   |
+
+## Quick Reference
+
+| Tool                                            | Purpose                                                                                                     |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `relevance_check_tool_integration_requirements` | Check a set of tools for missing OAuth accounts **and** API keys, with per-provider `setup_url` deep links. |
+| `relevance_check_api_key_availability`          | List API keys across the project/org, optionally filtered, each with a deep-link `setup_url`.               |
+
+See also [integration-setup.md](integration-setup.md) for the combined OAuth + API-key overview, and [oauth.md](oauth.md) for the OAuth-side authoring/connection flow.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/creating.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/creating.md
@@ -1,23 +1,29 @@
+---
+title: Creating Tools
+description: Detailed workflow for creating Relevance AI tools — config shape, transformation steps, params/state mapping, output schemas, step editing, and version handling. Load when the SKILL.md overview isn't enough and you need step-by-step config detail.
+---
+
 # Creating Tools
 
 Complete workflow for creating Relevance AI tools (studios).
 
 ## Creating New Tools
 
-### Option 1: Direct Creation with `relevance_upsert_tool`
+### Option 1: Direct Creation with `relevance_create_tool`
 
-Omit `studio_id` to create a new tool with auto-generated UUID:
+Auto-generates a UUID and saves the new tool as a DRAFT — call `relevance_publish_tool` to make it live:
 
 ```typescript
-relevance_upsert_tool({
-  title: "My New Tool",           // REQUIRED for new tools
+relevance_create_tool({
+  title: "My New Tool",           // REQUIRED
   description: "What it does",
   prompt_description: "When AI should use this",
   params_schema: { ... },
   transformations: { steps: [...] },
   state_mapping: { ... }
 })
-// Returns { studio_id: "auto-generated-uuid", version_id: "...", created: true }
+// Returns { studio_id: "auto-generated-uuid", url }
+// Tool is saved as a DRAFT — not yet live. Call relevance_publish_tool to publish.
 ```
 
 ### Option 2: Create from Transformation
@@ -44,13 +50,15 @@ relevance_create_tool_from_transformation({
 
 ## Updating Existing Tools
 
-Provide `studio_id` to update - MCP auto-fetches and merges:
+`relevance_update_tool` auto-fetches the current draft and shallow-merges your fields. It saves to a DRAFT only — call `relevance_publish_tool` when ready:
 
 ```typescript
-relevance_upsert_tool({
+relevance_update_tool({
   studio_id: 'existing-tool-id',
   emoji: '🔍', // Only this changes, everything else preserved
 });
+// Then publish when the user confirms:
+// relevance_publish_tool({ tool_id: 'existing-tool-id' });
 ```
 
 ## Tool Structure
@@ -92,8 +100,7 @@ interface TransformationStep {
 ## Creating a Basic Tool
 
 ```typescript
-relevance_upsert_tool({
-  studio_id: 'my-tool',
+relevance_create_tool({
   title: 'My Tool',
   description: 'What this tool does',
   prompt_description: 'Instructions for AI on when to use this tool',
@@ -192,6 +199,18 @@ params: {
 }
 ```
 
+## Input Naming Rules
+
+> **⚠️ Every `params_schema` property MUST have `title` and `description`.** Tools with unnamed inputs are unusable — agents cannot reason about what to pass, and users editing the tool have no context. Always infer meaningful names from the property key, the transformation it feeds into, and the user's stated intent.
+
+```typescript
+// WRONG — blank or missing title/description
+{ query: { type: "string" } }
+
+// CORRECT — named and described
+{ query: { type: "string", title: "Search Query", description: "The search term to look up" } }
+```
+
 ## Parameter Schema Types
 
 ### String Parameter
@@ -267,55 +286,55 @@ Run steps conditionally:
 }
 ```
 
-## Emoji Formats
+## Emoji / Icon
 
-Tools support these emoji formats:
-
-| Format           | Example                              | Use Case                     |
-| ---------------- | ------------------------------------ | ---------------------------- |
-| Unicode emoji    | `"🔍"`                               | Default, simplest option     |
-| CDN URL          | `"https://cdn.example.com/icon.svg"` | Brand icons, custom graphics |
-| Agent avatar URL | `"https://..."`                      | Match agent branding         |
+The `emoji` field accepts a unicode emoji or a full CDN URL to a brand SVG. **Prefer the brand icon when the tool wraps a known provider** (Slack, HubSpot, Gmail, etc.). See the **Tool Icons** section in [SKILL.md](SKILL.md#tool-icons) for the URL pattern, the list of available filenames, and the common-mistake table.
 
 ## Testing After Creation
 
 ```typescript
 // Sync execution
 relevance_run_tool({
-  studioId: 'my-tool',
+  studio_id: 'my-tool',
   params: { query: 'test query' },
 });
 ```
 
 ## Publishing
 
-After creation, the tool is in draft. To make it active:
+Both create and update save to a DRAFT — publishing is always a separate, user-confirmed step:
+
+- **Creating a new tool** (`relevance_create_tool`): saves to a draft. The new tool has only a draft version; call `relevance_publish_tool` to make it live.
+- **Updating an existing tool** (`relevance_update_tool`): saves to a draft only — the live version is unchanged until you call `relevance_publish_tool`.
+
+`relevance_publish_tool` always shows an approval card to the user (even with auto-approve enabled), so confirm in chat before calling it:
 
 ```typescript
-relevance_publish_tool({ toolId: 'my-tool' });
+relevance_publish_tool({ tool_id: 'my-tool' });
+```
+
+Test the draft first using `relevance_run_tool` with `version: "draft"`:
+
+```typescript
+relevance_run_tool({
+  studio_id: 'my-tool',
+  params: { query: 'test query' },
+  version: 'draft',
+});
 ```
 
 ---
 
-## `transformations` is Replaced, Not Deep-Merged
+## Editing Transformation Steps
 
-The MCP auto-merge preserves top-level fields you omit (e.g., providing only `emoji` keeps your existing `transformations`). But if you DO provide `transformations`, the entire object — including the `steps` array — is replaced wholesale. To update a single step in a multi-step tool, you must get the tool first, modify the specific step, then upsert with ALL steps:
+To edit transformation steps, use the dedicated per-step tools (all save to DRAFT only):
 
-```typescript
-// WRONG — replaces ALL steps with just this one
-relevance_upsert_tool({
-  studio_id: 'x',
-  transformations: { steps: [modified_step_2_only] },
-});
+- `relevance_add_tool_step({ studio_id, step, position? })` — insert a new step. `position` is 0-based; omit (or pass a value `>= step_count`) to append.
+- `relevance_update_tool_step({ studio_id, step_index, patch })` — shallow-merge `patch` into the step at 0-based `step_index`.
+- `relevance_remove_tool_step({ studio_id, step_index })` — remove a single step (0-based).
+- `relevance_move_tool_step({ studio_id, from_index, to_index })` — reorder a step (both 0-based; mirrors UI drag).
 
-// CORRECT — preserves all other steps
-const { studio } = await relevance_get_tool({ studioId: 'x' });
-studio.transformations.steps[1].params.code = newCode;
-relevance_upsert_tool({
-  studio_id: 'x',
-  transformations: studio.transformations,
-});
-```
+Always call `relevance_get_tool` first to confirm step indices in the current draft. Out-of-range indices throw with the current step count in the error message, so the LLM can recover.
 
 ---
 
@@ -390,28 +409,7 @@ The `state_mapping` connects two things:
 
 ## Fixing Auto-Generated Tool Outputs
 
-Tools created by `relevance_create_tool_from_transformation` often return empty `{}` because output fields aren't mapped. To fix:
-
-1. **Check the transformation's `output_schema`** to find available fields
-2. **Add explicit output mappings** to the step
-3. **Fix the final output reference** to point to the correct step output
-
-```typescript
-// BROKEN (auto-generated):
-{ name: "my_step", transformation: "some_transformation", output: {} }
-
-// FIXED (explicit mapping — check output_schema for actual field names):
-{ name: "my_step", transformation: "some_transformation",
-  output: { results: "{{results}}", metadata: "{{metadata}}" } }
-```
-
-| Config           | Broken (auto-generated)         | Working (fixed)                         |
-| ---------------- | ------------------------------- | --------------------------------------- |
-| Step output      | `"output": {}`                  | `"output": {"field": "{{field}}", ...}` |
-| Final output ref | `"answer": "{{stepname.data}}"` | `"answer": "{{stepname.actual_field}}"` |
-| State mapping    | Missing step entries            | `"stepname": "steps.stepname.output"`   |
-
-**Tip:** When in doubt, find a working tool in the project that uses the same transformation and copy its output pattern.
+Tools created by `relevance_create_tool_from_transformation` often return empty `{}` because output fields aren't mapped. Call `relevance_get_transformation` for the underlying transformation and read its `output_schema` to find the available fields. Then call `relevance_update_tool` with the corrected step config: explicit `output` mappings on each step (`"output": { "field": "{{field}}" }`), the final output reference pointing at a real field on the step (`"answer": "{{stepname.actual_field}}"`), and matching `state_mapping` entries so the templates resolve. When in doubt, find a working tool that uses the same transformation and copy its output pattern.
 
 ## Discover Transformation Outputs via `output_schema`
 

--- a/plugins/relevance-ai/skills/managing-relevance-tools/integration-setup.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/integration-setup.md
@@ -1,0 +1,97 @@
+---
+title: Integration Setup
+description: Entry point for detecting and resolving missing OAuth accounts and API keys required by tools. Use when attaching tools to agents, diagnosing auth failures, or before triggering agents.
+---
+
+# Integration Setup
+
+Tools authenticate with external services in one of two ways. This doc is the router — use the MCP tools below to detect what's missing, then jump to the right deep-dive.
+
+## OAuth vs API keys
+
+|                       | **OAuth**                                                                        | **API keys**                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Scope                 | Per tool parameter — the user picks an account for each tool                     | Per project/org — one key is reused by every tool that needs that provider                                    |
+| Tool schema           | Declared as a `params_schema` property with `content_type: "oauth_account"`      | Declared by the underlying transformation, not by the tool itself — so it does not appear as a tool parameter |
+| Where users configure | Integrations page → OAuth provider drawer (login flow)                           | Integrations page → API key provider drawer (paste secret)                                                    |
+| MCP can auto-fill     | Yes — `relevance_attach_tools_to_agent` sets the account ID as the param default | No — the key is looked up at runtime from the project/org                                                     |
+
+## When to Check
+
+- **After `relevance_attach_tools_to_agent`** — its `integration_warnings` lists tools needing OAuth or API keys.
+- **When tools fail** — errors like `"You need to add your chains_xxx_api_key"` or `"Invalid OAuth account"` indicate missing integrations.
+- **Before triggering an agent** — verify integrations are configured so the run doesn't fail mid-conversation.
+
+## Detecting missing integrations
+
+```typescript
+relevance_check_tool_integration_requirements({
+  tool_ids: ['tool-id-1', 'tool-id-2'],
+  agent_id: 'agent-xxx', // optional — adds per-tool config_url
+});
+```
+
+Response shape (trimmed):
+
+```json
+{
+  "tools": [
+    {
+      "studio_id": "tool-id-1",
+      "title": "Search HubSpot Contacts",
+      "oauth_requirements": [
+        {
+          "provider": "hubspot",
+          "status": "missing",
+          "setup_url": "https://app.relevanceai.com/integrations/us-east/proj-xxx?provider=hubspot&type=oauth"
+        }
+      ],
+      "api_key_requirements": [
+        {
+          "provider": "firecrawl",
+          "provider_label": "Firecrawl API Key",
+          "status": "missing",
+          "has_platform_key": false,
+          "setup_url": "https://app.relevanceai.com/integrations/us-east/proj-xxx?provider=firecrawl&type=api_key"
+        }
+      ]
+    }
+  ],
+  "action_required": true,
+  "missing_oauth": [
+    /* deduped by provider across all tools */
+  ],
+  "missing_api_keys": [
+    /* deduped by provider across all tools */
+  ],
+  "setup_url": "https://app.relevanceai.com/integrations/..."
+}
+```
+
+**Status values:**
+
+- `configured` — user or org already has a key/account; tool will work.
+- `platform_key_available` (API keys only) — Relevance has a shared key fallback; the tool will work, user can optionally add their own.
+- `missing` — user action required. Send them the entry's `setup_url`.
+
+## Directing the user
+
+Always prefer the per-entry `setup_url` over the top-level one — it opens the provider's drawer directly. For API keys, show the `provider_label` (e.g. "Firecrawl API Key"), never the raw `provider` identifier.
+
+> Your tool _"Search HubSpot Contacts"_ needs a HubSpot OAuth connection. Please connect here: {setup_url}
+
+After the user reports they've added it, re-run `relevance_check_tool_integration_requirements` (or `relevance_check_api_key_availability` for keys only) to verify.
+
+## What next
+
+- **API-key specifics** — multi-key providers (Twilio, AWS Bedrock, Azure OpenAI, GCP Vertex, Marketo, ZoomInfo), LLM platform-key semantics, common error strings, and `provider_label` guidance → see [api-keys.md](api-keys.md).
+- **OAuth param authoring** — how to declare `content_type: "oauth_account"`, and the `is_fixed_param` + `default` pattern for agent-called tools → see [oauth.md](oauth.md).
+
+## Quick Reference
+
+| Tool                                            | Purpose                                                                      |
+| ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| `relevance_check_tool_integration_requirements` | Check what integrations tools need, cross-referenced against configured ones |
+| `relevance_check_api_key_availability`          | Check which API keys are configured at project/org level                     |
+| `relevance_list_oauth_accounts`                 | List connected OAuth accounts                                                |
+| `relevance_list_integration_providers`          | List available integration providers                                         |

--- a/plugins/relevance-ai/skills/managing-relevance-tools/oauth.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/oauth.md
@@ -1,6 +1,13 @@
+---
+title: OAuth Account Configuration
+description: Wire OAuth account selection into tools — `params_schema` setup, passing the account into transformation steps, provider reference, and agent-tool quirks. Load when building a tool that hits a user-authenticated API (HubSpot, Gmail, etc.).
+---
+
 # OAuth Account Configuration
 
 How to add OAuth account selection to tools for third-party integrations.
+
+> **Directing a user to connect an account?** Always use the per-provider `setup_url` from `tools_needing_oauth[].providers[].setup_url` or `missing_oauth[].setup_url` (same pattern as API keys). It deep-links to the integrations page with the correct provider drawer already open. Never hand-roll a generic integrations URL — the user shouldn't have to scroll a grid to find the provider they need. See [integration-setup.md](integration-setup.md) for the end-to-end detection → connect → verify workflow.
 
 ## Overview
 
@@ -89,8 +96,7 @@ Reference the OAuth parameter using `oauth_account_id`:
 ## Complete Example: Ahrefs Backlink Tool
 
 ```typescript
-relevance_upsert_tool({
-  studio_id: 'backlink-analyzer',
+relevance_create_tool({
   title: 'Backlink Analyzer',
   description: 'Analyze backlinks using Ahrefs',
   params_schema: {
@@ -184,42 +190,9 @@ relevance_api_request({
 
 ## CRITICAL: OAuth for Agent-Called Tools
 
-When a tool is called by an **agent** (not directly by a user), the OAuth account must be provided via a `default` value in the tool's `params_schema`.
+Agent actions can't carry `oauth_account_id` directly — the action config schema has no `params` field, and trying to add one fails with `"must NOT have additional properties"`. Common symptom: `"You need to add your chains_<provider>_api_key API key"`.
 
-### The Problem
-
-```typescript
-// WRONG - Agent actions don't support params field
-agent.actions.push({
-  chain_id: 'hubspot-search-contact',
-  params: { oauth_account_id: 'xxx' }, // ERROR: "must NOT have additional properties"
-});
-```
-
-**Symptom:** Error like "You need to add your chains_hubspot_api_key API key"
-
-### The Solution
-
-Add `default` value AND `is_fixed_param: true` in the **tool's** params_schema:
-
-```typescript
-params_schema: {
-  type: "object",
-  properties: {
-    oauth_account_id: {
-      type: "string",
-      title: "HubSpot Account",
-      default: "your-oauth-account-id",  // <-- CRITICAL!
-      metadata: {
-        is_fixed_param: true,  // Hides from UI
-        content_type: "oauth_account",
-        oauth_account_provider: "hubspot",
-        oauth_permissions: [{ provider: "hubspot", types: ["hubspot-connect-app"] }]
-      }
-    }
-  }
-}
-```
+**Fix:** put the OAuth account on the **tool**, not the action. Call `relevance_update_tool` with a `params_schema` patch that sets, on the OAuth param: `default: "<oauth_account_id>"` (provides the value when the tool is called without it) AND `metadata.is_fixed_param: true` (hides the field from the UI). Both are required — `is_fixed_param` alone does not provide a value. Keep the rest of the OAuth metadata (`content_type: "oauth_account"`, `oauth_account_provider`, `oauth_permissions`) intact.
 
 ### Key Insights
 

--- a/plugins/relevance-ai/skills/managing-relevance-tools/patterns.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/patterns.md
@@ -1,3 +1,8 @@
+---
+title: Common Tool Patterns
+description: Reusable tool design patterns — search + analyse, scrape + extract, multi-query loops, URL processing, enrichment, conditional branching, error handling. Load when designing multi-step tools or you need worked examples.
+---
+
 # Common Tool Patterns
 
 Reusable patterns for building Relevance AI tools.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/reference.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/reference.md
@@ -1,3 +1,8 @@
+---
+title: API Reference
+description: Lookups for transformation discovery, conversation job queries, OAuth provider lists, and raw API fallback via `relevance_api_request`. Load when the dedicated MCP tools don't cover your operation.
+---
+
 # API Reference
 
 Additional API details for operations not covered by dedicated MCP tools.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/running.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/running.md
@@ -1,3 +1,8 @@
+---
+title: Running and Testing Tools
+description: Run and debug tools — sync/async invocation, polling pacing, per-step testing, output inspection, common errors like timeouts and `variable_not_found`. Load when a tool fails or you need to test it end-to-end.
+---
+
 # Running and Testing Tools
 
 How to execute tools, handle async operations, and debug issues.
@@ -8,7 +13,7 @@ For tools that complete quickly:
 
 ```typescript
 relevance_run_tool({
-  studioId: 'my-tool',
+  studio_id: 'my-tool',
   params: { query: 'test input' },
 });
 ```
@@ -22,25 +27,32 @@ For long-running tools:
 ```typescript
 // 1. Start async execution
 const { job_id } = await relevance_trigger_tool_async({
-  studioId: 'my-tool',
+  studio_id: 'my-tool',
   params: { query: 'test input' },
 });
 
-// 2. Poll for results
+// 2. Poll for results — always pass wait_seconds
 relevance_poll_tool_result({
-  studioId: 'my-tool',
-  jobId: job_id,
+  studio_id: 'my-tool',
+  job_id: job_id,
+  wait_seconds: 50,
 });
 ```
 
-### Poll Response States
+### Polling Pacing
 
-| Status      | Meaning               |
-| ----------- | --------------------- |
-| `pending`   | Job queued            |
-| `running`   | Currently executing   |
-| `completed` | Finished successfully |
-| `failed`    | Execution failed      |
+Always pass `wait_seconds` (default 50s, max 300s). The platform-API holds the connection open until the tool reaches a terminal `type` (`complete` or `failed`) or the wait window elapses, so one call covers many internal polls.
+
+If a poll returns a non-terminal `type` (`inprogress` or `timeout`), **re-poll** — do NOT call `relevance_trigger_tool_async` again. Re-triggering starts a fresh job; the existing one is still running.
+
+### Poll Response Types
+
+| Type         | Meaning                            |
+| ------------ | ---------------------------------- |
+| `complete`   | Finished successfully (terminal)   |
+| `failed`     | Execution failed (terminal)        |
+| `inprogress` | Currently executing — re-poll      |
+| `timeout`    | Server-side wait elapsed — re-poll |
 
 ## Getting Latest Run
 
@@ -48,7 +60,7 @@ Useful for getting example task IDs:
 
 ```typescript
 relevance_get_latest_tool_run({
-  studioId: 'my-tool',
+  studio_id: 'my-tool',
 });
 ```
 
@@ -58,7 +70,7 @@ relevance_get_latest_tool_run({
 
 ```typescript
 relevance_run_tool({
-  studioId: 'my-tool',
+  studio_id: 'my-tool',
   params: { query: 'simple test' },
 });
 ```

--- a/plugins/relevance-ai/skills/managing-relevance-tools/transformations-catalog.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/transformations-catalog.md
@@ -1,3 +1,8 @@
+---
+title: Popular Transformations Catalog
+description: Categorised quick-lookup table of popular transformations (LLM, search, API, web scraping, code execution, email, integrations). Load when you need the right transformation name without reading the full reference.
+---
+
 # Popular Transformations Catalog
 
 Quick reference for the most commonly used tool-step transformations in Relevance AI.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/transformations.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/transformations.md
@@ -1,3 +1,8 @@
+---
+title: Transformations Reference
+description: Implementation reference for transformations — input/output patterns, parameter schemas, gotchas per type, and worked examples for `prompt_completion`, `browserless_scrape`, `api_call`, code steps, and more. Load when the catalog entry isn't enough.
+---
+
 # Transformations Reference
 
 Complete reference for transformation types and their outputs.

--- a/plugins/relevance-ai/skills/managing-relevance-tools/versions.md
+++ b/plugins/relevance-ai/skills/managing-relevance-tools/versions.md
@@ -1,3 +1,8 @@
+---
+title: Version Management
+description: Recover tools from accidental edits using version snapshots, and apply targeted per-step edits without overwriting the rest. Load when a tool's config is wiped or you need to safely edit one step in isolation.
+---
+
 # Version Management
 
 How to recover tools from accidental changes using version history.
@@ -21,7 +26,7 @@ Every time you publish a tool, a version snapshot is saved. If you accidentally 
 
 ```
 relevance_list_tool_versions({
-  toolId: "my-tool-id"
+  tool_id: "my-tool-id"
 })
 ```
 
@@ -35,7 +40,7 @@ To inspect a specific version in detail:
 
 ```
 relevance_get_tool_version({
-  versionId: "version-uuid"
+  version_id: "version-uuid"
 })
 ```
 
@@ -43,7 +48,7 @@ relevance_get_tool_version({
 
 ```
 relevance_restore_tool_version({
-  versionId: "working-version-uuid"
+  version_id: "working-version-uuid"
 })
 ```
 
@@ -53,28 +58,20 @@ This creates a new draft from the specified version.
 
 ```
 relevance_publish_tool({
-  toolId: "my-tool-id"
+  tool_id: "my-tool-id"
 })
 ```
 
-## Preventing Accidental Wipes
+## Editing Steps Without Wiping the Rest
 
-### The MCP Auto-Merge
+For step edits, use the dedicated per-step tools, all of which save to DRAFT only:
 
-`relevance_upsert_tool` auto-merges with the existing tool config — top-level fields you omit are preserved.
+- `relevance_add_tool_step` — insert at a 0-based `position` (default = append; pass `position >= step_count` to append explicitly).
+- `relevance_update_tool_step` — shallow-merge a patch into one step by 0-based `step_index`.
+- `relevance_remove_tool_step` — remove one step by 0-based `step_index`.
+- `relevance_move_tool_step` — reorder by `from_index` → `to_index` (both 0-based; mirrors UI drag).
 
-**However**, `transformations` is replaced as a whole object. If you provide it, ALL steps must be included. To update one step in a 7-step tool, get the tool first with `relevance_get_tool`, modify that step in `transformations.steps`, then upsert with the complete `transformations`.
-
-### Always Get Before Partial Updates
-
-```
-# WRONG — wipes transformations!
-relevance_upsert_tool({ studio_id: "my-tool", emoji: "new-emoji" })
-
-# CORRECT — get first, then upsert with all fields
-# 1. relevance_get_tool({ studioId: "my-tool" })
-# 2. relevance_upsert_tool({ ...full_config, emoji: "new-emoji" })
-```
+Always call `relevance_get_tool` first to confirm current step indices. The same principle holds for the agent side: never pass `actions` to `relevance_update_agent` — use `relevance_attach_tools_to_agent` / `relevance_update_agent_action` / `relevance_detach_tools_from_agent`.
 
 ## Version Retention
 

--- a/plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md
+++ b/plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md
@@ -1,3 +1,8 @@
+---
+title: Debugging Workforce Execution
+description: Inspect workforce execution logs, extract agent outputs, and diagnose stuck tasks, context loss, and node failures. Load when troubleshooting a workforce run or recovering results from a completed execution.
+---
+
 # Debugging Workforce Execution
 
 ## Getting Execution Details
@@ -40,7 +45,7 @@ The `results` array contains execution events with nested agent messages:
           name: "Lead Researcher"
         },
         task_details: {
-          conversation_id: "abc123",  // Agent's conversation ID
+          conversation_id: "abc123",  // Agent's conversation ID (use as task_id in agent task tools)
           finished_state: "completed"
         }
       },
@@ -77,7 +82,7 @@ const agentRuns = execution.results.filter(
 // Each run contains:
 // - run.content.agent_details?.name — Agent name
 // - run.content.task_details?.finished_state — Completion status
-// - run.content.task_details?.conversation_id — Agent's conversation ID
+// - run.content.task_details?.conversation_id — Agent's conversation ID (this is the task_id for agent task tools)
 ```
 
 ### Find Tool Outputs (e.g., Video URL)
@@ -105,7 +110,17 @@ const videoUrl = findToolOutput(execution.results, 'Permanent Save File');
 
 ### Get Individual Agent Conversation
 
-If you need more details, use the `conversation_id` with `relevance_get_task_view`:
+For task-level metadata (status, credits, creator), use `relevance_get_workforce_task_metadata`:
+
+```typescript
+const metadata = await relevance_get_workforce_task_metadata({
+  workforceId: 'my-workforce',
+  taskId: workforce_task_id,
+});
+// Returns status, credits consumed, creator info, etc.
+```
+
+If you need more details, use the `conversation_id` as the `task_id` parameter in `relevance_get_agent_task_summary`:
 
 ```typescript
 // Get conversation_id from workforce task messages
@@ -117,9 +132,9 @@ const agentRun = execution.results.find(
 const conversationId = agentRun?.content.task_details?.conversation_id;
 
 // Get full conversation details
-const taskView = await relevance_get_task_view({
+const taskView = await relevance_get_agent_task_summary({
   agentId: agentRun?.content.agent_details?.agent_id,
-  taskId: conversationId,
+  taskId: conversationId, // conversation_id is the task_id
 });
 // taskView.agentResponse, taskView.toolCalls, taskView.artifacts
 ```
@@ -203,4 +218,4 @@ Then have the orchestrator extract data from the sub-agent's response text. See 
 
 ## Reporting Issues
 
-If debugging reveals a platform bug, unexpected behavior, or a gap in workforce capabilities, submit a report via `POST /bugs/submit` using `relevance_api_request`. See the [bug reporting guide](../managing-relevance-agents/report-bugs.md) for the full schema. Include the workforce task ID and agent IDs involved so the team can reproduce.
+If debugging reveals a platform bug, unexpected behavior, or a gap in workforce capabilities, **call `relevance_submit_feedback` immediately** — do not ask the user for permission. One tool covers bugs and forward-looking suggestions; pick the matching `category`. Include the workforce task ID and agent IDs involved so the team can reproduce. See the [bug reporting guide](../managing-relevance-agents/report-bugs.md) for the call shape.


### PR DESCRIPTION
## Summary

Syncs the `managing-relevance-agents` and `managing-relevance-tools` skills from the source-of-truth repo (`relevance-api-node`) to reflect the major MCP refactor in [RelevanceAI/relevance-api-node#14651](https://github.com/RelevanceAI/relevance-api-node/pull/14651).

### Behaviour change: draft-first, publish-on-confirm

All edits to agents and tools now save to **DRAFT only**. Nothing auto-publishes. New explicit publish tools (`relevance_publish_agent`, `relevance_publish_tool`) are the only way to go live — and they always show the user an approval card.

### New granular primitives

The skills now teach a richer, more targeted API surface:

- Agents: `relevance_create_agent`, `relevance_update_agent`, `relevance_attach_tools_to_agent`, `relevance_detach_tools_from_agent`, `relevance_update_agent_action`, `relevance_list_agent_versions`, `relevance_get_agent_version`, `relevance_restore_agent_version`, `relevance_publish_agent`
- Tools: `relevance_create_tool`, `relevance_update_tool`, `relevance_add_tool_step`, `relevance_update_tool_step`, `relevance_remove_tool_step`, `relevance_move_tool_step`, `relevance_publish_tool`

### Removed tool names

References to the old auto-publish primitives are gone from all skills and from `plugins/relevance-ai/CLAUDE.md`:

- `upsert_agent`
- `patch_agent`
- `save_agent_draft`
- `upsert_tool`

## Files synced

**`managing-relevance-agents/`** (11 modified):
SKILL.md, actions.md, creating.md, memory.md, phantom-tools.md, phone-agents.md, report-bugs.md, running.md, system-prompts.md, triggers.md, troubleshooting.md

**`managing-relevance-tools/`** (9 modified, 2 added):
- Modified: SKILL.md, creating.md, oauth.md, patterns.md, reference.md, running.md, transformations-catalog.md, transformations.md, versions.md
- Added: api-keys.md, integration-setup.md

**Plugin metadata:**
- `.claude-plugin/marketplace.json` — `version` bumped `1.3.0` -> `1.4.0`
- `plugins/relevance-ai/.claude-plugin/plugin.json` — `version` bumped `1.3.0` -> `1.4.0`
- `plugins/relevance-ai/CLAUDE.md` — Publish Behavior table and partial-update example rewritten to remove stale tool names and document the draft-first model

## Test plan

- [ ] Skills surface only documented MCP tool names (no `upsert_agent` / `patch_agent` / `save_agent_draft` / `upsert_tool` anywhere in `plugins/relevance-ai/`)
- [ ] Version is `1.4.0` in both `marketplace.json` and `plugin.json`
- [ ] `diff -rq` against the source-of-truth `relevance-api-node` skill dirs produces zero output for `managing-relevance-agents/` and `managing-relevance-tools/`
- [ ] Spot-check `SKILL.md` in both skills loads in Claude Code and references the new tool names
- [ ] Spot-check `plugins/relevance-ai/CLAUDE.md` Publish Behavior table reflects draft-first model

---

## Follow-up commit (additional stale refs)

After the initial sync, a deeper audit caught more stale MCP tool references missed in the first pass. Fixed in commit `e2c7ed4`:

### `plugins/relevance-ai/CLAUDE.md`

- **"Attaching Tools to Agents"** section: replaced phantom `relevance_trigger_tool` (does not exist in the canonical tool list) with `relevance_trigger_tool_async`.
- **"Handling Large MCP Tool Outputs"** section: replaced removed `relevance_trigger_agent_sync` (deleted in upstream PR #14608) and deprecated `relevance_get_task_view` with the current canonical names that actually return large payloads: `relevance_get_agent_task_summary`, `relevance_list_agent_task_messages`, and `relevance_poll_agent_result`.

### `plugins/relevance-ai/skills/managing-relevance-workforces/debugging.md`

Wholesale resync from source-of-truth — the local copy had significantly drifted. Brings in:
- Updated `relevance_get_agent_task_summary` calls (replacing deprecated `relevance_get_task_view`)
- New `relevance_get_workforce_task_metadata` section
- `relevance_submit_feedback` guidance
- Skill frontmatter

### Version bump

- `1.4.0` -> `1.4.1` (patch) in both `.claude-plugin/marketplace.json` and `plugins/relevance-ai/.claude-plugin/plugin.json` — these are follow-on bug fixes within the same MCP-refactor sync work.
